### PR TITLE
ci: added python package python-pkcs11

### DIFF
--- a/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
@@ -47,7 +47,7 @@ jobs:
           python -m pip install --upgrade pip
           $env:PATH+=":/root/.cargo/bin"
           rustc --version
-          .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography")
+          .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
       - name: Copy cached wheels
         run: cp -u `pip cache list --format=abspath` download
       - name: Test wheels by installation

--- a/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
@@ -51,7 +51,7 @@ jobs:
           python -m pip install --upgrade pip
           $env:PATH+=":/root/.cargo/bin"
           rustc --version
-          .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography")
+          .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
       - name: Copy cached wheels
         run: cp -u `pip cache list --format=abspath` download
       - name: Test wheels by installation

--- a/.github/workflows/build-wheels-macos-M1-self-hosted.yml
+++ b/.github/workflows/build-wheels-macos-M1-self-hosted.yml
@@ -68,7 +68,7 @@ jobs:
           $env:CPPFLAGS="-I/Users/githubrunner/brew/opt/openssl/include"
           $env:LDFLAGS="-L/Users/githubrunner/brew/opt/openssl/lib"
           arch -arm64 pip3 install wheel
-          .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "-arm64" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography") -Python ~/.pyenv/versions/${{ matrix.python-version }}/bin/python
+          .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "-arm64" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11") -Python ~/.pyenv/versions/${{ matrix.python-version }}/bin/python
       - name: Test wheels by installation
         shell: pwsh
         run: |

--- a/.github/workflows/build-wheels-macos-dispatch.yml
+++ b/.github/workflows/build-wheels-macos-dispatch.yml
@@ -50,7 +50,7 @@ jobs:
           fi
       - name: Build wheels for IDF ${{ env.IDF_branch }} branch
         shell: pwsh
-        run: .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography")
+        run: .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
       - name: Test wheels by installation
         shell: pwsh
         run: .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}"

--- a/.github/workflows/build-wheels-ubuntu-dispatch.yml
+++ b/.github/workflows/build-wheels-ubuntu-dispatch.yml
@@ -54,7 +54,7 @@ jobs:
           fi
       - name: Build wheels for IDF ${{ env.IDF_branch }} branch
         shell: pwsh
-        run: .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography")
+        run: .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
       - name: Test wheels by installation
         shell: pwsh
         run: .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }}

--- a/.github/workflows/build-wheels-windows-dispatch.yml
+++ b/.github/workflows/build-wheels-windows-dispatch.yml
@@ -54,7 +54,7 @@ jobs:
           fi
       - name: Build wheels for IDF ${{ env.IDF_branch }} branch
         shell: pwsh
-        run: .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "windows-curses")
+        run: .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "windows-curses", "python-pkcs11")
       - name: Test wheels by installation
         shell: pwsh
         run: .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -61,7 +61,7 @@ jobs:
         run: python3 -m pip install wheel
       - name: Build wheels for IDF master
         shell: pwsh
-        run: .\Build-Wheels.ps1  -Branch "master" -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "windows-curses")
+        run: .\Build-Wheels.ps1  -Branch "master" -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "windows-curses", "python-pkcs11")
       - name: Test wheels by installation
         shell: pwsh
         run: .\Test-Wheels.ps1 -Branch "master" -Arch "${{ matrix.ARCH }}"

--- a/Build-Wheels.ps1
+++ b/Build-Wheels.ps1
@@ -10,7 +10,7 @@ param (
 "Using Python: $Python"
 $env:IDF_PATH=(Get-Location).Path
 
-$BranchNum = ($Branch -replace "\D+[^0-9][^0-9]" , '')
+ $BranchNum = ($Branch -replace "\D+[^0-9][^0-9]" , '')
 
 if ($BranchNum -eq "") {
     $BranchNum = "5.1" # master

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ The build contains all wheels required by branches:
 ## Usage for x64 build
 
 ```
-.\Build-Wheels.ps1 -Branch "master" -Arch "" -CompileWheels @("greenlet", "gevent<2.0,>=1.2.2", "cryptography", "windows-curses") -Python python3.9
+.\Build-Wheels.ps1 -Branch "master" -Arch "" -CompileWheels @("greenlet", "gevent<2.0,>=1.2.2", "cryptography", "windows-curses", "python-pkcs11") -Python python3.9
 .\Test-Wheels.ps1 -Branch "master"
 ```
 
 ## Usage for arm64 build
 
 ```
-.\Build-Wheels.ps1 -Branch "master" -Arch "-arm64" -CompileWheels @("greenlet", "gevent<2.0,>=1.2.2", "cryptography", "windows-curses") -Python python3.9
+.\Build-Wheels.ps1 -Branch "master" -Arch "-arm64" -CompileWheels @("greenlet", "gevent<2.0,>=1.2.2", "cryptography", "windows-curses", "python-pkcs11") -Python python3.9
 .\Test-Wheels.ps1 -Branch "master"
 ```


### PR DESCRIPTION
PyKCS11 is a package which is required for using `espsecure.esp_hsm_sign` package in `esptool.py`.
Attached are the logs of `.\Build-Wheels.ps1` and `.\Test-Wheels.ps1` commands during the local run.
[build-wheels-x64.log](https://github.com/espressif/idf-python-wheels/files/10313896/build-wheels-x64.log)
[test-wheels-x64.log](https://github.com/espressif/idf-python-wheels/files/10313901/test-wheels-x64.log)