### PR TITLE
allow to build wheels for selected packages only

### DIFF
--- a/.github/workflows/build-wheels-ad-hoc.yml
+++ b/.github/workflows/build-wheels-ad-hoc.yml
@@ -1,0 +1,101 @@
+name: ad-hoc-wheels
+on:
+  workflow_dispatch:
+    inputs:
+      IDF_branch:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
+        required: false
+        default: 'master'
+      packages:
+        description: >
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
+
+      # Unfortunately gitlab doesn't support something like checkbox,
+      # so it's emulated with boolean.
+      os_ubuntu_latest:
+        description: Build on ubuntu-latest(x86_64)
+        type: boolean
+        required: false
+        default: true
+      os_windows_latest:
+        description: Build on windows-latest(x86_64)
+        type: boolean
+        required: false
+        default: true
+      os_macos_latest:
+        description: Build on macos-latest(x86_64)
+        type: boolean
+        required: false
+        default: true
+      os_macos_arm64:
+        description: Build on macos M1(aarch64)
+        type: boolean
+        required: false
+        default: true
+      os_linux_armv7:
+        description: Build on linux armv7(aarch32)
+        type: boolean
+        required: false
+        default: true
+      os_linux_arm64:
+        description: Build on linux arm64(aarch64)
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+  ubuntu-latest:
+    name: linux x86_64
+    if: ${{ inputs.os_ubuntu_latest }}
+    uses: ./.github/workflows/build-wheels-ubuntu-dispatch.yml
+    with:
+      IDF_branch: ${{ inputs.IDF_branch }}
+      packages: ${{ inputs.packages }}
+    secrets: inherit
+  windows-latest:
+    name: windows x86_64
+    if: ${{ inputs.os_windows_latest }}
+    uses: ./.github/workflows/build-wheels-windows-dispatch.yml
+    with:
+      IDF_branch: ${{ inputs.IDF_branch }}
+      packages: ${{ inputs.packages }}
+    secrets: inherit
+  macos-latest:
+    name: macos x86_64
+    if: ${{ inputs.os_macos_latest }}
+    uses: ./.github/workflows/build-wheels-macos-dispatch.yml
+    with:
+      IDF_branch: ${{ inputs.IDF_branch }}
+      packages: ${{ inputs.packages }}
+    secrets: inherit
+  macos-m1:
+    name: macos aarch64
+    if: ${{ inputs.os_macos_arm64 }}
+    uses: ./.github/workflows/build-wheels-macos-M1-self-hosted.yml
+    with:
+      IDF_branch: ${{ inputs.IDF_branch }}
+      packages: ${{ inputs.packages }}
+    secrets: inherit
+  linux-armv7:
+    name: linux aarch32
+    if: ${{ inputs.os_linux_armv7 }}
+    uses: ./.github/workflows/build-wheels-linux-armv7-self-hosted.yml
+    with:
+      IDF_branch: ${{ inputs.IDF_branch }}
+      packages: ${{ inputs.packages }}
+    secrets: inherit
+  linux-arm64:
+    name: linux aarch64
+    if: ${{ inputs.os_linux_arm64 }}
+    uses: ./.github/workflows/build-wheels-linux-arm64-self-hosted.yml
+    with:
+      IDF_branch: ${{ inputs.IDF_branch }}
+      packages: ${{ inputs.packages }}
+    secrets: inherit

--- a/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
@@ -6,9 +6,37 @@ on:
   workflow_dispatch:
     inputs:
       IDF_branch:
-        description: 'Wheels will be built for this branch'
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
         required: false
         default: 'master'
+      packages:
+        description: >
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      IDF_branch:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
+        required: false
+        default: 'master'
+      packages:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
 
 jobs:
   build-python-wheels:
@@ -22,6 +50,14 @@ jobs:
       image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v1
       options: --privileged
     steps:
+      - name: Prepare package list
+        if: ${{ inputs.packages }}
+        run: |
+          echo "input packages: ${{ inputs.packages }}"
+          PACKAGES=$(echo "${{ inputs.packages }}" |
+                     sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\([^[:space:]]\{1,\}\)/"\1"/g;s/[[:space:]]\{1,\}/,/g')
+          echo "packages=$PACKAGES" >> $GITHUB_ENV
+          echo "output packages: $PACKAGES"
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Prepare download folder
@@ -47,12 +83,21 @@ jobs:
           python -m pip install --upgrade pip
           $env:PATH+=":/root/.cargo/bin"
           rustc --version
-          .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+          if ( "${{ inputs.packages }}" ) {
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -NoReq -CompileWheels @(${{ env.packages }})
+          } else {
+            .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+          }
       - name: Copy cached wheels
         run: cp -u `pip cache list --format=abspath` download
       - name: Test wheels by installation
         shell: pwsh
-        run: .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }}
+        run: |
+          if ( "${{ inputs.packages }}" ) {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -TestWheels @(${{ env.packages }})
+          } else {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }}
+          }
       - name: Upload Release Asset To test s3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
@@ -6,9 +6,37 @@ on:
   workflow_dispatch:
     inputs:
       IDF_branch:
-        description: 'Wheels will be built for this branch'
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
         required: false
         default: 'master'
+      packages:
+        description: >
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      IDF_branch:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
+        required: false
+        default: 'master'
+      packages:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
 
 jobs:
   build-python-wheels:
@@ -22,6 +50,14 @@ jobs:
       image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v1
       options: --privileged
     steps:
+      - name: Prepare package list
+        if: ${{ inputs.packages }}
+        run: |
+          echo "input packages: ${{ inputs.packages }}"
+          PACKAGES=$(echo "${{ inputs.packages }}" |
+                     sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\([^[:space:]]\{1,\}\)/"\1"/g;s/[[:space:]]\{1,\}/,/g')
+          echo "packages=$PACKAGES" >> $GITHUB_ENV
+          echo "output packages: $PACKAGES"
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Prepare download folder
@@ -51,12 +87,21 @@ jobs:
           python -m pip install --upgrade pip
           $env:PATH+=":/root/.cargo/bin"
           rustc --version
-          .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+          if ( "${{ inputs.packages }}" ) {
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -NoReq -CompileWheels @(${{ env.packages }})
+          } else {
+            .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+          }
       - name: Copy cached wheels
         run: cp -u `pip cache list --format=abspath` download
       - name: Test wheels by installation
         shell: pwsh
-        run: .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }}
+        run: |
+          if ( "${{ inputs.packages }}" ) {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -TestWheels @(${{ env.packages }})
+          } else {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }}
+          }
       - name: Upload Release Asset To test s3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-wheels-macos-M1-self-hosted.yml
+++ b/.github/workflows/build-wheels-macos-M1-self-hosted.yml
@@ -137,3 +137,9 @@ jobs:
           ./Upload-Wheels.sh $AWS_BUCKET
           pip3 install boto3
           python3 create_index_pages.py $AWS_BUCKET
+      - name: Drop AWS cache
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"

--- a/.github/workflows/build-wheels-macos-M1-self-hosted.yml
+++ b/.github/workflows/build-wheels-macos-M1-self-hosted.yml
@@ -6,9 +6,38 @@ on:
   workflow_dispatch:
     inputs:
       IDF_branch:
-        description: 'Wheels will be built for this branch'
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
         required: false
         default: 'master'
+      packages:
+        description: >
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      IDF_branch:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
+        required: false
+        default: 'master'
+      packages:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
+
 jobs:
   build-python-wheels:
     name: Build Python Wheels for macos-M1
@@ -18,6 +47,14 @@ jobs:
       matrix:
         python-version: ['3.8.12', '3.9.4', '3.10.2']
     steps:
+      - name: Prepare package list
+        if: ${{ inputs.packages }}
+        run: |
+          echo "input packages: ${{ inputs.packages }}"
+          PACKAGES=$(echo "${{ inputs.packages }}" |
+                     sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\([^[:space:]]\{1,\}\)/"\1"/g;s/[[:space:]]\{1,\}/,/g')
+          echo "packages=$PACKAGES" >> $GITHUB_ENV
+          echo "output packages: $PACKAGES"
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Cache Python
@@ -68,7 +105,11 @@ jobs:
           $env:CPPFLAGS="-I/Users/githubrunner/brew/opt/openssl/include"
           $env:LDFLAGS="-L/Users/githubrunner/brew/opt/openssl/lib"
           arch -arm64 pip3 install wheel
-          .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "-arm64" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11") -Python ~/.pyenv/versions/${{ matrix.python-version }}/bin/python
+          if ( "${{ inputs.packages }}" ) {
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -NoReq -CompileWheels @(${{ env.packages }})
+          } else {
+            .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "-arm64" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11") -Python ~/.pyenv/versions/${{ matrix.python-version }}/bin/python
+          }
       - name: Copy cached wheels
         run: |
           arch -arm64 brew install coreutils
@@ -78,7 +119,11 @@ jobs:
         run: |
           $env:CPPFLAGS="-I/Users/githubrunner/brew/opt/openssl/include"
           $env:LDFLAGS="-L/Users/githubrunner/brew/opt/openssl/lib"
-          .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "-arm64" -Python ~/.pyenv/versions/${{ matrix.python-version }}/bin/python
+          if ( "${{ inputs.packages }}" ) {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "-arm64" -Python ~/.pyenv/versions/${{ matrix.python-version }}/bin/python -TestWheels @(${{ env.packages }})
+          } else {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "-arm64" -Python ~/.pyenv/versions/${{ matrix.python-version }}/bin/python
+          }
       - name: Upload Release Asset To test s3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-wheels-macos-dispatch.yml
+++ b/.github/workflows/build-wheels-macos-dispatch.yml
@@ -6,9 +6,37 @@ on:
   workflow_dispatch:
     inputs:
       IDF_branch:
-        description: 'Wheels will be built for this branch'
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
         required: false
         default: 'master'
+      packages:
+        description: >
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      IDF_branch:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
+        required: false
+        default: 'master'
+      packages:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
 
 jobs:
   build-python-wheels:
@@ -19,6 +47,14 @@ jobs:
       matrix:
         python-version: ['3.7.10', '3.8.12', '3.9.9', '3.10.2']
     steps:
+      - name: Prepare package list
+        if: ${{ inputs.packages }}
+        run: |
+          echo "input packages: ${{ inputs.packages }}"
+          PACKAGES=$(echo "${{ inputs.packages }}" |
+                     sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\([^[:space:]]\{1,\}\)/"\1"/g;s/[[:space:]]\{1,\}/,/g')
+          echo "packages=$PACKAGES" >> $GITHUB_ENV
+          echo "output packages: $PACKAGES"
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up Python
@@ -50,14 +86,24 @@ jobs:
           fi
       - name: Build wheels for IDF ${{ env.IDF_branch }} branch
         shell: pwsh
-        run: .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+        run: |
+          if ( "${{ inputs.packages }}" ) {
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -NoReq -CompileWheels @(${{ env.packages }})
+          } else {
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+          }
       - name: Copy cached wheels
         run: |
           brew install coreutils
           rsync -u `python3 -m pip cache list --format=abspath` download
       - name: Test wheels by installation
         shell: pwsh
-        run: .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}"
+        run: |
+          if ( "${{ inputs.packages }}" ) {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -TestWheels @(${{ env.packages }})
+          } else {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}"
+          }
       - name: Upload Release Asset To test s3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-wheels-macos-dispatch.yml
+++ b/.github/workflows/build-wheels-macos-dispatch.yml
@@ -117,3 +117,9 @@ jobs:
           ./Upload-Wheels.sh $AWS_BUCKET
           pip3 install boto3
           python3 create_index_pages.py $AWS_BUCKET
+      - name: Drop AWS cache
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"

--- a/.github/workflows/build-wheels-ubuntu-dispatch.yml
+++ b/.github/workflows/build-wheels-ubuntu-dispatch.yml
@@ -6,9 +6,37 @@ on:
   workflow_dispatch:
     inputs:
       IDF_branch:
-        description: 'Wheels will be built for this branch'
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
         required: false
         default: 'master'
+      packages:
+        description: >
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      IDF_branch:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
+        required: false
+        default: 'master'
+      packages:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
 
 jobs:
   build-python-wheels:
@@ -19,6 +47,14 @@ jobs:
       matrix:
         python-version: ['3.7.15', '3.8.12', '3.9.15', '3.10.8']
     steps:
+      - name: Prepare package list
+        if: ${{ inputs.packages }}
+        run: |
+          echo "input packages: ${{ inputs.packages }}"
+          PACKAGES=$(echo "${{ inputs.packages }}" |
+                     sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\([^[:space:]]\{1,\}\)/"\1"/g;s/[[:space:]]\{1,\}/,/g')
+          echo "packages=$PACKAGES" >> $GITHUB_ENV
+          echo "output packages: $PACKAGES"
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up Python
@@ -54,10 +90,20 @@ jobs:
           fi
       - name: Build wheels for IDF ${{ env.IDF_branch }} branch
         shell: pwsh
-        run: .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+        run: |
+          if ( "${{ inputs.packages }}" ) {
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -NoReq -CompileWheels @(${{ env.packages }})
+          } else {
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+          }
       - name: Test wheels by installation
         shell: pwsh
-        run: .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }}
+        run: |
+          if ( "${{ inputs.packages }}" ) {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -TestWheels @(${{ env.packages }})
+          } else {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }}
+          }
       - name: Upload Release Asset To test s3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-wheels-windows-dispatch.yml
+++ b/.github/workflows/build-wheels-windows-dispatch.yml
@@ -6,9 +6,37 @@ on:
   workflow_dispatch:
     inputs:
       IDF_branch:
-        description: 'Wheels will be built for this branch'
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
         required: false
         default: 'master'
+      packages:
+        description: >
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      IDF_branch:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+        type: string
+        required: false
+        default: 'master'
+      packages:
+        description: >
+          Wheels will be built for this branch. This will
+          be ignored if specific packages are listed bellow.
+          Generate wheels for given packages separated by space.
+          Requirement specifiers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2
+        type: string
+        required: false
 
 jobs:
   build-python-wheels:
@@ -19,6 +47,15 @@ jobs:
       matrix:
         python-version: ['3.7.9', '3.8.10', '3.9.9', '3.10.2']
     steps:
+      - name: Prepare package list
+        shell: bash
+        if: ${{ inputs.packages }}
+        run: |
+          echo "input packages: ${{ inputs.packages }}"
+          PACKAGES=$(echo "${{ inputs.packages }}" |
+                     sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\([^[:space:]]\{1,\}\)/"\1"/g;s/[[:space:]]\{1,\}/,/g')
+          echo "packages=$PACKAGES" >> $GITHUB_ENV
+          echo "output packages: $PACKAGES"
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up Python
@@ -54,10 +91,20 @@ jobs:
           fi
       - name: Build wheels for IDF ${{ env.IDF_branch }} branch
         shell: pwsh
-        run: .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "windows-curses", "python-pkcs11")
+        run: |
+          if ( "${{ inputs.packages }}" ) {
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -NoReq -CompileWheels @(${{ env.packages }})
+          } else {
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "windows-curses", "python-pkcs11")
+          }
       - name: Test wheels by installation
         shell: pwsh
-        run: .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}"
+        run: |
+          if ( "${{ inputs.packages }}" ) {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -TestWheels @(${{ env.packages }})
+          } else {
+            .\Test-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}"
+          }
       - name: Upload Release Asset To test s3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Build-Wheels.ps1
+++ b/Build-Wheels.ps1
@@ -43,22 +43,27 @@ foreach ($wheelPrefix in $CompileWheels) {
     }
 
     "Processing: $wheel"
+    # Split by default splits on each space, so empty args are passed as
+    # requirements to pip-wheel, which complains with
+    # ERROR: Invalid requirement: ''
+    # "   ".Split() vs. "   ".split() | where {$_}
+    $OnlyBinarySplitted = $OnlyBinary.Split(' ') | where {$_}
     if ("$Arch" -eq "") {
-        &$Python -m pip wheel --find-links download --wheel-dir download $OnlyBinary.Split(' ') $wheel
+        &$Python -m pip wheel --find-links download --wheel-dir download $OnlyBinarySplitted $wheel
     } else {
-        arch $Arch $Python -m pip wheel --find-links download --wheel-dir download $OnlyBinary.Split(' ') $wheel
+        arch $Arch $Python -m pip wheel --find-links download --wheel-dir download $OnlyBinarySplitted $wheel
     }
     #$cache=pip cache dir
     #Get-ChildItem -Path $cache "{$wheel}*.whl" -Recurse | % {Copy-Item -Path $_.FullName -Destination download -Container }
     #ls download
-    $OnlyBinary += " --only-binary $wheel "
+    $OnlyBinary += " --only-binary $wheel"
 }
 
-
+$OnlyBinarySplitted = $OnlyBinary.Split(' ') | where {$_}
 if ("$Arch" -eq "") {
-    &$Python -m pip download $OnlyBinary.Split(' ') --find-links download --dest download -r $RequirementsTxt
+    &$Python -m pip download $OnlyBinarySplitted --find-links download --dest download -r $RequirementsTxt
 } else {
-    arch $Arch $Python -m pip download $OnlyBinary.Split(' ') --find-links download --dest download -r $RequirementsTxt
+    arch $Arch $Python -m pip download $OnlyBinarySplitted --find-links download --dest download -r $RequirementsTxt
 }
 
 &$Python -m pip wheel --wheel-dir download --find-links download -r $RequirementsTxt

--- a/Build-Wheels.ps1
+++ b/Build-Wheels.ps1
@@ -4,7 +4,8 @@ param (
     [string]$Branch="main",
     [string]$Python="python3",
     [string]$Arch="",
-    [string[]]$CompileWheels=@()
+    [string[]]$CompileWheels=@(),
+    [switch]$NoReq=$false
 )
 
 "Using Python: $Python"
@@ -57,6 +58,10 @@ foreach ($wheelPrefix in $CompileWheels) {
     #Get-ChildItem -Path $cache "{$wheel}*.whl" -Recurse | % {Copy-Item -Path $_.FullName -Destination download -Container }
     #ls download
     $OnlyBinary += " --only-binary $wheel"
+}
+
+if ($NoReq) {
+    exit
 }
 
 $OnlyBinarySplitted = $OnlyBinary.Split(' ') | where {$_}

--- a/Test-Wheels.ps1
+++ b/Test-Wheels.ps1
@@ -3,12 +3,22 @@
 param (
     [string]$Branch="main",
     [string]$Python="python3",
-    [string]$Arch=""
+    [string]$Arch="",
+    [string[]]$TestWheels=@()
 )
 
 $env:IDF_PATH=(Get-Location).Path
 $FileBranch = ${Branch}.Replace('/', '_')
 $RequirementsTxt="requirements-${FileBranch}.txt"
+
+if (@($TestWheels).length) {
+    if ("$Arch" -eq "") {
+        &$Python -m pip install --no-index --find-links download $TestWheels
+    } else {
+        arch $Arch $Python -m pip install --no-index --find-links download $TestWheels
+    }
+    exit
+}
 
 if ("$Arch" -eq "") {
     &$Python -m pip install --no-index --find-links download -r $RequirementsTxt


### PR DESCRIPTION
Currently packages are built based on the requirements files only. This PR adds a new manual workflow, which allows to build specific packages with requirement specifiers manually for selected operating systems/architectures.