### PR TITLE
build cmake for linux-armv7

### DIFF
--- a/.github/workflows/build-cmake-linux-armv7.yml
+++ b/.github/workflows/build-cmake-linux-armv7.yml
@@ -1,0 +1,57 @@
+name: armv7-cmake-dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      cmake_version:
+        description: >
+          Cmake version to build and upload
+          For example 3.23.1
+        type: string
+        required: true
+        default: 'master'
+
+jobs:
+  build-cmake:
+    name: Build cmake for linux-armv7
+    runs-on: linux-armv7-self-hosted
+    container:
+      image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v1
+      options: --privileged
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Download and unpack cmake
+        shell: bash
+        run: |
+          wget "https://github.com/Kitware/CMake/releases/download/v${{ inputs.cmake_version }}/cmake-${{ inputs.cmake_version }}.tar.gz"
+          tar -xf "cmake-${{ inputs.cmake_version }}.tar.gz"
+      - name: Build cmake
+        shell: bash
+        run: |
+          cd "cmake-${{ inputs.cmake_version }}"
+          mkdir cmake-build
+          cd cmake-build
+          ../bootstrap && make && make install
+      - name: Create packages
+        shell: bash
+        working-directory: 'cmake-${{ inputs.cmake_version }}/cmake-build'
+        run: cpack -G TGZ && cpack -G STGZ
+      - name: Upload cmake to s3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_BUCKET: ${{ secrets.DL_BUCKET }}
+          PREFIX: 'dl/cmake'
+        shell: bash
+        working-directory: 'cmake-${{ inputs.cmake_version }}/cmake-build'
+        run: |
+          aws s3 cp --acl=public-read --no-progress "cmake-${{ inputs.cmake_version }}-Linux-armv7l.tar.gz" "s3://$AWS_BUCKET/dl/cmake/cmake-${{ inputs.cmake_version }}-Linux-armv7l.tar.gz"
+      - name: Drop AWS cache
+        id: invalidate-index-cache
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/dl/cmake/*"

--- a/.github/workflows/build-cmake-linux-armv7.yml
+++ b/.github/workflows/build-cmake-linux-armv7.yml
@@ -9,12 +9,13 @@ on:
           For example 3.23.1
         type: string
         required: true
-        default: 'master'
 
 jobs:
   build-cmake:
     name: Build cmake for linux-armv7
-    runs-on: linux-armv7-self-hosted
+    runs-on:
+      - self-hosted
+      - ARM
     container:
       image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v1
       options: --privileged


### PR DESCRIPTION
CMake is not prebuilt for armv7, developers need to build it themselves and upload it manually.
This PR automates the task.