### PR TITLE
Add initial support for custom build environment 

### DIFF
--- a/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
@@ -86,7 +86,10 @@ jobs:
           if ( "${{ inputs.packages }}" ) {
             .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -NoReq -CompileWheels @(${{ env.packages }})
           } else {
-            .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+            # Cython==3.0.0 breaks the build of gevent. The build environment from https://github.com/gevent/gevent/blob/1.5.0/pyproject.toml
+            # must be patched with "cython<3"
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -BuildEnv @("setuptools", "wheel", "cython<3", "cffi") -CompileWheels @("gevent==1.5.0")
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("cryptography", "python-pkcs11")
           }
       - name: Copy cached wheels
         run: cp -u `pip cache list --format=abspath` download

--- a/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
@@ -90,7 +90,10 @@ jobs:
           if ( "${{ inputs.packages }}" ) {
             .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -NoReq -CompileWheels @(${{ env.packages }})
           } else {
-            .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+            # Cython==3.0.0 breaks the build of gevent. The build environment from https://github.com/gevent/gevent/blob/1.5.0/pyproject.toml
+            # must be patched with "cython<3"
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -BuildEnv @("setuptools", "wheel", "cython<3", "cffi") -CompileWheels @("gevent==1.5.0")
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("cryptography", "python-pkcs11")
           }
       - name: Copy cached wheels
         run: cp -u `pip cache list --format=abspath` download

--- a/.github/workflows/build-wheels-macos-M1-self-hosted.yml
+++ b/.github/workflows/build-wheels-macos-M1-self-hosted.yml
@@ -108,7 +108,10 @@ jobs:
           if ( "${{ inputs.packages }}" ) {
             .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -NoReq -CompileWheels @(${{ env.packages }})
           } else {
-            .\Build-Wheels.ps1 -Branch ${{ env.IDF_branch }} -Arch "-arm64" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11") -Python ~/.pyenv/versions/${{ matrix.python-version }}/bin/python
+            # Cython==3.0.0 breaks the build of gevent. The build environment from https://github.com/gevent/gevent/blob/1.5.0/pyproject.toml
+            # must be patched with "cython<3"
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -BuildEnv @("setuptools", "wheel", "cython<3", "cffi") -CompileWheels @("gevent==1.5.0") -Python ~/.pyenv/versions/${{ matrix.python-version }}/bin/python
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("cryptography", "python-pkcs11") -Python ~/.pyenv/versions/${{ matrix.python-version }}/bin/python
           }
       - name: Copy cached wheels
         run: |

--- a/.github/workflows/build-wheels-macos-dispatch.yml
+++ b/.github/workflows/build-wheels-macos-dispatch.yml
@@ -90,7 +90,10 @@ jobs:
           if ( "${{ inputs.packages }}" ) {
             .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -NoReq -CompileWheels @(${{ env.packages }})
           } else {
-            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+            # Cython==3.0.0 breaks the build of gevent. The build environment from https://github.com/gevent/gevent/blob/1.5.0/pyproject.toml
+            # must be patched with "cython<3"
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -BuildEnv @("setuptools", "wheel", "cython<3", "cffi") -CompileWheels @("gevent==1.5.0")
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("cryptography", "python-pkcs11")
           }
       - name: Copy cached wheels
         run: |

--- a/.github/workflows/build-wheels-ubuntu-dispatch.yml
+++ b/.github/workflows/build-wheels-ubuntu-dispatch.yml
@@ -94,7 +94,10 @@ jobs:
           if ( "${{ inputs.packages }}" ) {
             .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -NoReq -CompileWheels @(${{ env.packages }})
           } else {
-            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "python-pkcs11")
+            # Cython==3.0.0 breaks the build of gevent. The build environment from https://github.com/gevent/gevent/blob/1.5.0/pyproject.toml
+            # must be patched with "cython<3"
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -BuildEnv @("setuptools", "wheel", "cython<3", "cffi") -CompileWheels @("gevent==1.5.0")
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("cryptography", "python-pkcs11")
           }
       - name: Test wheels by installation
         shell: pwsh

--- a/.github/workflows/build-wheels-windows-dispatch.yml
+++ b/.github/workflows/build-wheels-windows-dispatch.yml
@@ -95,7 +95,10 @@ jobs:
           if ( "${{ inputs.packages }}" ) {
             .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -NoReq -CompileWheels @(${{ env.packages }})
           } else {
-            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -CompileWheels @("greenlet==1.0.0", "gevent==1.5.0", "cryptography", "windows-curses", "python-pkcs11")
+            # Cython==3.0.0 breaks the build of gevent. The build environment from https://github.com/gevent/gevent/blob/1.5.0/pyproject.toml
+            # must be patched with "cython<3"
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -BuildEnv @("setuptools", "wheel", "cython<3", "cffi") -CompileWheels @("gevent==1.5.0")
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("cryptography", "windows-curses", "python-pkcs11")
           }
       - name: Test wheels by installation
         shell: pwsh


### PR DESCRIPTION
The build action started to fail for `gevent=1.5.0`. The build environment of gevent doesn't have an upper bound for cython (https://github.com/gevent/gevent/blob/1.5.0/pyproject.toml#L17) and version 3 introduced some breaking changes.

This is the patch what we need to apply here:
```sh
pip install wheel "Cython<3" setuptools cffi greenlet
pip install --no-build-isolation "gevent==1.5.0"
```

This PR adds `-BuildEnv` for `Build-Wheels.ps1` which enables us to pre-install packages and then use them as build environment.

Note: Disabling the build isolation might cause other issues in the future but for now it patches the issue.