### PR TITLE
change(pyenv-image): Update version of build pyenv image

### DIFF
--- a/.github/workflows/build-cmake-linux-armv7.yml
+++ b/.github/workflows/build-cmake-linux-armv7.yml
@@ -17,7 +17,7 @@ jobs:
       - self-hosted
       - ARM
     container:
-      image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v1
+      image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v2
       options: --privileged
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         python-version: ['3.8.17', '3.9.17', '3.10.12', '3.11.4']
     container:
-      image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v1
+      image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v2
       options: --privileged
     steps:
       - name: Prepare package list

--- a/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         python-version: ['3.8.17', '3.9.17', '3.10.12', '3.11.4']
     container:
-      image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v1
+      image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v2
       options: --privileged
     steps:
       - name: Prepare package list


### PR DESCRIPTION
Updates version of image used for building wheels.

Spotted in https://github.com/espressif/idf-python-wheels/pull/11:
Update of Python versions in caused fails in the build process (at least for armv7 / .github/workflows/build-wheels-linux-armv7-self-hosted.yml), as this action uses a custom image with pyenv installed with different versions:

https://github.com/espressif/github-esp-dockerfiles/blob/master/pyenv_rust_powershell/Dockerfile#L36-L61
This results in build fails due to a non-matching Python version, such as here:

https://github.com/espressif/idf-python-wheels/actions/runs/5876118264/job/15933787010#step:7:216


## Related
- https://github.com/espressif/github-esp-dockerfiles/pull/5

***

**! Do NOT merge this before image is build and pushed** to registry: https://github.com/espressif/github-esp-dockerfiles/actions/runs/5889166692/job/15971791947