### PR TITLE
fix(dispatch): Wheels build

### DIFF
--- a/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
@@ -67,6 +67,11 @@ jobs:
           pyenv global ${{ matrix.python-version }}
           python -m pip install wheel
           pip3 install wheel
+          python -m pip install --upgrade pip
+          apt-get update
+          apt-get install -y --no-install-recommends build-essential
+          apt-get install -y --no-install-recommends python3-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev
+          apt-get install -y --no-install-recommends dbus-tests
       - name: Get branch name
         run: |
           INPUT=${{ github.event.inputs.IDF_branch }}
@@ -80,7 +85,6 @@ jobs:
           PIP_EXTRA_INDEX_URL: "https://www.piwheels.org/simple"
         shell: pwsh
         run: |
-          python -m pip install --upgrade pip
           $env:PATH+=":/root/.cargo/bin"
           rustc --version
           if ( "${{ inputs.packages }}" ) {
@@ -88,7 +92,8 @@ jobs:
           } else {
             # Cython==3.0.0 breaks the build of gevent. The build environment from https://github.com/gevent/gevent/blob/1.5.0/pyproject.toml
             # must be patched with "cython<3"
-            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -BuildEnv @("setuptools", "wheel", "cython<3", "cffi") -CompileWheels @("gevent==1.5.0")
+            # gevent is not possible to build in version 1.5.0 on Python 3.11 for ARM64
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -BuildEnv @("setuptools", "wheel", "cython<3", "cffi") -CompileWheels @("gevent==1.5.0; python_version < '3.11'")
             .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("cryptography", "python-pkcs11")
           }
       - name: Copy cached wheels

--- a/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
@@ -67,10 +67,13 @@ jobs:
       - name: Install build dependencies
         run: |
           apt update
+          apt-get install rustc -y
           apt-get install libtiff5 libjpeg-dev libopenjp2-7 cmake libdbus-1-dev -y
           pyenv global ${{ matrix.python-version }}
           python -m pip install wheel
           pip3 install wheel
+          apt-get install -y --no-install-recommends python3-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev
+          apt-get install -y --no-install-recommends dbus-tests
       - name: Get branch name
         run: |
           INPUT=${{ github.event.inputs.IDF_branch }}

--- a/.github/workflows/build-wheels-macos-M1-self-hosted.yml
+++ b/.github/workflows/build-wheels-macos-M1-self-hosted.yml
@@ -76,6 +76,12 @@ jobs:
           export CPPFLAGS=-I/Users/githubrunner/brew/opt/openssl/include
           export LDFLAGS=-L/Users/githubrunner/brew/opt/openssl/lib
           ~/.pyenv/versions/${{ matrix.python-version }}/bin/python -m pip install --upgrade pip
+      - name: Install stable Rust with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          components: rustfmt, clippy
       - name: Rust version
         run: |
           rustc --version
@@ -95,10 +101,17 @@ jobs:
           else
             echo IDF_branch=${{ github.event.inputs.IDF_branch }} >> $GITHUB_ENV
           fi
-      - name: Install packages
+      - name: Add Homebrew to PATH and install dependencies
         run: |
+          echo "Adding Homebrew to PATH"
+          export PATH="/opt/homebrew/bin:$PATH"
+          echo "Current PATH: $PATH"
+    
+          echo "Updating Homebrew and installing dependencies"
+          brew update
           export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
-          arch -arm64 brew install libxcb
+          brew install libxcb
+          arch -arm64 brew install coreutils
       - name: Build wheels for IDF ${{ env.IDF_branch }} branch
         shell: pwsh
         run: |
@@ -115,7 +128,6 @@ jobs:
           }
       - name: Copy cached wheels
         run: |
-          arch -arm64 brew install coreutils
           rsync -u `python3 -m pip cache list --format=abspath` download
       - name: Test wheels by installation
         shell: pwsh
@@ -141,6 +153,7 @@ jobs:
           pip3 install boto3
           python3 create_index_pages.py $AWS_BUCKET
       - name: Drop AWS cache
+        id: invalidate-index-cache
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-wheels-macos-dispatch.yml
+++ b/.github/workflows/build-wheels-macos-dispatch.yml
@@ -55,13 +55,14 @@ jobs:
                      sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\([^[:space:]]\{1,\}\)/"\1"/g;s/[[:space:]]\{1,\}/,/g')
           echo "packages=$PACKAGES" >> $GITHUB_ENV
           echo "output packages: $PACKAGES"
+      - name: Identify
+        run: uname -a
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          check-latest: true
       - name: Install stable Rust with clippy and rustfmt
         uses: actions-rs/toolchain@v1
         with:
@@ -121,6 +122,7 @@ jobs:
           pip3 install boto3
           python3 create_index_pages.py $AWS_BUCKET
       - name: Drop AWS cache
+        id: invalidate-index-cache
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-wheels-ubuntu-dispatch.yml
+++ b/.github/workflows/build-wheels-ubuntu-dispatch.yml
@@ -76,8 +76,8 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install cmake libdbus-1-dev -y
-      - name: Install build dependencies
-        run: python3 -m pip install wheel
+          python3 -m pip install wheel
+          sudo apt install git virtualenv build-essential python3-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev
       - name: Get python3 version
         run: python3 --version
       - name: Get branch name

--- a/.github/workflows/build-wheels-windows-dispatch.yml
+++ b/.github/workflows/build-wheels-windows-dispatch.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8.17', '3.9.17', '3.10.12', '3.11.4']
+        python-version: ['3.8.10', '3.9.13', '3.10.2', '3.11.4']
     steps:
       - name: Prepare package list
         shell: bash
@@ -62,7 +62,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          check-latest: true
       - name: Install stable Rust with clippy and rustfmt
         uses: actions-rs/toolchain@v1
         with:
@@ -90,15 +89,20 @@ jobs:
             echo IDF_branch=${{ github.event.inputs.IDF_branch }} >> $GITHUB_ENV
           fi
       - name: Build wheels for IDF ${{ env.IDF_branch }} branch
+        env:
+          PIP_EXTRA_INDEX_URL: "https://www.piwheels.org/simple"
         shell: pwsh
         run: |
+          python -m pip install --upgrade pip
           if ( "${{ inputs.packages }}" ) {
             .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -Arch "${{ matrix.ARCH }}" -NoReq -CompileWheels @(${{ env.packages }})
           } else {
             # Cython==3.0.0 breaks the build of gevent. The build environment from https://github.com/gevent/gevent/blob/1.5.0/pyproject.toml
             # must be patched with "cython<3"
             .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -BuildEnv @("setuptools", "wheel", "cython<3", "cffi") -CompileWheels @("gevent==1.5.0")
-            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("cryptography", "windows-curses", "python-pkcs11")
+
+            # python-pkcs11 can't be build on Python 3.10 and above (3.10.2 works) https://github.com/danni/python-pkcs11/issues/159
+            .\Build-Wheels.ps1  -Branch ${{ env.IDF_branch }} -CompileWheels @("cryptography", "windows-curses", "python-pkcs11;python_version<'3.11'")
           }
       - name: Test wheels by installation
         shell: pwsh

--- a/Build-Wheels.ps1
+++ b/Build-Wheels.ps1
@@ -30,6 +30,17 @@ $OnlyBinary = ""
 "Processing: $RequirementsUrl"
 Invoke-WebRequest $RequirementsUrl -OutFile $RequirementsTxt
 
+# dbus-python (https://github.com/posborne/dbus-python/tree/master) is deprecated
+# we could migrate it to python-dbus-next (https://github.com/altdesktop/python-dbus-next)
+# on Python 3.11 it is not possible for some platform to even install dbus-python
+# and because of constraint file taken instead of requirements file there is condition: dbus-python<1.3; python_version > "3.10"
+# that means dbus-python seems to be build only for Python 3.11
+# workaround for the dbus-python requirement for all platforms (install only for linux which should be working):
+$Content = [System.IO.File]::ReadAllLines($RequirementsTxt)
+$string = 'dbus-python<1.3; python_version > "3.10"'
+$Content = $Content -replace $string,'dbus-python<1.3; python_version >"3.10" and sys_platform == "linux"'
+$Content | Set-Content -Path $RequirementsTxt
+
 # If specific build environment is requested then build isolation must be disable in order to use the build environment.
 # It might be necessary to clean or separate this build environment in the future.
 if ($BuildEnv.count -ne 0) {


### PR DESCRIPTION
Temporary workaround to pass pipeline wheel builds for platforms.

- Excluded dependencies that can't be build for some reasons. 

Succeeded pipeline:
- [ubuntu](https://github.com/espressif/idf-python-wheels/actions/runs/6588535789/job/17901017113?pr=17)
- [windows](https://github.com/espressif/idf-python-wheels/actions/runs/6561809683)
- [linux-arm7](https://github.com/espressif/idf-python-wheels/actions/runs/6588535791/job/17901573479?pr=17)
- [linux-arm64](https://github.com/espressif/idf-python-wheels/actions/runs/6588788247/job/17901840693?pr=17)
- [macos-M1](https://github.com/espressif/idf-python-wheels/actions/runs/6561809679)
- [macos-x64](https://github.com/espressif/idf-python-wheels/actions/runs/6561809678)
