### PR TITLE
Feat/build wheels improvement

### DIFF
--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -1,7 +1,9 @@
-name: windows-dispatch
+name: platforms-dispatches
 
 # TODO schedule for workflow and delete pull_request/push on final merge request
 on:
+  pull_request:
+  push:
   workflow_dispatch:
 
 env:
@@ -15,6 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TODO
+        # macos-M1 (macos-m1-self-hosted) has no 3.8 PYthon available
+        # linux-armv7-self-hosted: version `GLIBCXX_3.4.26' not found (required by /opt/actions-runner/externals/node20/bin/node)
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ['3.8']
 

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -1,8 +1,8 @@
 name: platforms-dispatches
 
-# TODO schedule for workflow and delete pull_request/push on final merge request
 on:
-  pull_request:
+  schedule:
+    - cron: '0 0 * * 0,3'
   workflow_dispatch:
 
 env:
@@ -17,23 +17,35 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          #- windows-latest
-          #- ubuntu-latest
-          #- macos-latest
-          #- linux-armv7-self-hosted
-          - macos-latest-xlarge        # MacOS M1 GitHub beta runner - paid $0.16
-          #- BrnoRPI-GH004             # linux ARM64
-        #include:
-          #- os: linux-armv7-self-hosted
-          #  CONTAINER: python:3.8-bullseye
-          #- os: BrnoRPI-GH004
-          #  CONTAINER: python:3.8-bullseye
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+          - linux-armv7-self-hosted
+          - macos-latest-xlarge       # MacOS M1 GitHub beta runner - paid $0.16
+          - BrnoRPI-GH004             # linux ARM64
+        include:
+          - os: linux-armv7-self-hosted
+            CONTAINER: python:3.8-bullseye
+          - os: BrnoRPI-GH004
+            CONTAINER: python:3.8-bullseye
         python-version: ['3.8']
 
     # Use python container on ARM
-    #container: ${{ matrix.CONTAINER }}
+    container: ${{ matrix.CONTAINER }}
 
     steps:
+      - name: OS info
+        if: matrix.os != 'windows-latest'
+        run: |
+          echo "Operating System: ${{ runner.os }}"
+          echo "Architecture: $(uname -m)"
+      - name: OS info
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "Operating System: ${{ runner.os }}"
+          echo "Architecture: $env:PROCESSOR_ARCHITECTURE"
+
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -84,8 +96,10 @@ jobs:
 
           # MacOS M1 additional dependencies
           if [ "${{ matrix.os }}" == "macos-latest-xlarge" ]; then
-            #arch -arm64 brew install coreutils
-            #arch -arm64 python -m pip install --no-binary gdbgui==0.13.2.0 gdbgui==0.13.2.0
+            # Probably temporary fix for gdbgui==0.13.2.0 on MacOS M1 -> gevent==1.5.0 can't be build
+            # The newest version of gevent with M1 support is installed and forced to be used for gdbgui
+            # When requirement wheels are build gdbgui==0.13.2.0 is already built
+
             arch -arm64 python -m pip install 'cython<3'
             arch -arm64 python -m pip install 'cffi'
             arch -arm64 python -m pip install 'gevent'
@@ -97,6 +111,9 @@ jobs:
         if: matrix.os == 'linux-armv7-self-hosted'
         run: |
           apt-get update
+
+          # AWS
+          apt-get install -y -q --no-install-recommends awscli
 
           # cryptography needs Rust
           curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain stable -y
@@ -116,11 +133,15 @@ jobs:
         run: |
           apt-get update
 
+          # AWS
+          apt-get install -y -q --no-install-recommends awscli
+
           # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
           apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev -y
 
 
       - name: Build wheels for IDF
+        if: matrix.os != 'windows-latest'
         run: |
           # Rust directory needs to be included for Linux ARM7
           if [ "${{ matrix.os }}" == "linux-armv7-self-hosted" ]; then
@@ -129,28 +150,30 @@ jobs:
 
           python build_wheels.py
 
+      - name: Build wheels for IDF - Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          python build_wheels.py
 
 
+      - name: Upload Release Asset To test S3 bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_BUCKET: ${{ secrets.DL_BUCKET }}
+          PREFIX: 'pypi'
+        shell: bash
+        run: |
+          chmod +x Upload-Wheels.sh
+          ./Upload-Wheels.sh $AWS_BUCKET
+          python create_index_pages.py $AWS_BUCKET
 
 
-      # - name: Upload Release Asset To test S3 bucket
-      #   env:
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      #     AWS_BUCKET: ${{ secrets.DL_BUCKET }}
-      #     PREFIX: 'pypi'
-      #   shell: bash
-      #   run: |
-      #     chmod +x Upload-Wheels.sh
-      #     ./Upload-Wheels.sh $AWS_BUCKET
-      #     pip3 install boto3
-      #     python3 create_index_pages.py $AWS_BUCKET
-
-      # - name: Drop AWS cache
-      #   id: invalidate-index-cache
-      #   env:
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      #   run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"
+      - name: Drop AWS cache
+        id: invalidate-index-cache
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -11,8 +11,8 @@ env:
   MIN_IDF_MINOR_VERSION: ${{ vars.MIN_IDF_MINOR_VERSION }}
 
 jobs:
-  build-python-wheels:
-    name: Build Python Wheels for ${{ matrix.os }}
+  prepare-environment38:
+    name: Prepare environment for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -74,7 +74,12 @@ jobs:
           python --version
           python -m pip install --upgrade pip
 
+  instal-dependencies:
+    needs: prepare-environment38
+    name: Install dependencies for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
+    steps:
       - name: Install build dependencies
         run: python -m pip install -r build_requirements.txt
 
@@ -118,7 +123,7 @@ jobs:
 
           # cryptography needs Rust
           curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain stable -y
-          . $HOME/.cargo/env
+          source $HOME/.cargo/env
 
           # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
           apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev -y
@@ -140,13 +145,18 @@ jobs:
           # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
           apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev -y
 
+  build-wheels:
+    needs: instal-dependencies
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
+    steps:
       - name: Build wheels for IDF
         if: matrix.os != 'windows-latest'
         run: |
           # Rust directory needs to be included for Linux ARM7
           if [ "${{ matrix.os }}" == "linux-armv7-self-hosted" ]; then
-            . $HOME/.cargo/env
+            source $HOME/.cargo/env
           fi
 
           python build_wheels.py
@@ -156,6 +166,12 @@ jobs:
         run: |
           python build_wheels.py
 
+  upload-to-aws:
+    needs: build-wheels
+    name: Upload wheels for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
 
       - name: Upload release asset to S3 bucket
         env:

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -5,7 +5,6 @@ on:
   #schedule:
   #  - cron: '0 0 * * 0,3'
   workflow_dispatch:
-  pull_request:
 
 env:
   MIN_IDF_MAJOR_VERSION: ${{ vars.MIN_IDF_MAJOR_VERSION }}

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -3,7 +3,6 @@ name: platforms-dispatches
 # TODO schedule for workflow and delete pull_request/push on final merge request
 on:
   pull_request:
-  push:
   workflow_dispatch:
 
 env:
@@ -12,33 +11,146 @@ env:
 
 jobs:
   build-python-wheels:
-    name: Build Python Wheels for windows-latest
+    name: Build Python Wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        # TODO
-        # macos-M1 (macos-m1-self-hosted) has no 3.8 PYthon available
-        # linux-armv7-self-hosted: version `GLIBCXX_3.4.26' not found (required by /opt/actions-runner/externals/node20/bin/node)
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os:
+          #- windows-latest
+          #- ubuntu-latest
+          #- macos-latest
+          #- linux-armv7-self-hosted
+          - macos-latest-xlarge        # MacOS M1 GitHub beta runner - paid $0.16
+          #- BrnoRPI-GH004             # linux ARM64
+        #include:
+          #- os: linux-armv7-self-hosted
+          #  CONTAINER: python:3.8-bullseye
+          #- os: BrnoRPI-GH004
+          #  CONTAINER: python:3.8-bullseye
         python-version: ['3.8']
+
+    # Use python container on ARM
+    #container: ${{ matrix.CONTAINER }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v3
+
+      - name: Setup Python
+        # GitHub action for MacOS M1 does not have Python <= 3.10
+        # Skip setting python on ARM because of missing compatibility: https://github.com/actions/setup-python/issues/108
+        if: matrix.os != 'macos-latest-xlarge' && matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'BrnoRPI-GH004'
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+
+      - name: Setup Python - MacOS M1
+        # Temporary solution until Python version for build will be >= 3.10 (GitHub action support)
+        if: matrix.os == 'macos-latest-xlarge'
+        run: |
+          brew install python@3.8
+          # change python symlink called with default command 'python'
+          ln -s -f /opt/homebrew/bin/python3.8 /usr/local/bin/python
+
 
       - name: Get Python version
         run: |
           python --version
           python -m pip install --upgrade pip
 
-      - name: Install build dependencis
-        run: pip install -r build_requirements.txt
+
+      - name: Install build dependencies
+        run: python -m pip install -r build_requirements.txt
+
+
+      - name: Install additional OS dependencies - Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
+          sudo apt install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-4.0 -y
+
+          # dbus-python needs build dependecies
+          sudo apt-get install cmake build-essential libdbus-1-dev libdbus-glib-1-dev -y
+
+
+      - name: Install additional OS dependencies - MacOS
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-latest-xlarge'
+        run: |
+          # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
+          brew install pygobject3 gtk4
+
+          # MacOS M1 additional dependencies
+          if [ "${{ matrix.os }}" == "macos-latest-xlarge" ]; then
+            #arch -arm64 brew install coreutils
+            #arch -arm64 python -m pip install --no-binary gdbgui==0.13.2.0 gdbgui==0.13.2.0
+            arch -arm64 python -m pip install 'cython<3'
+            arch -arm64 python -m pip install 'cffi'
+            arch -arm64 python -m pip install 'gevent'
+            arch -arm64 python -m pip install 'gdbgui==0.13.2.0' --no-build-isolation
+          fi
+
+
+      - name: Install additional OS dependencies - Linux ARM7
+        if: matrix.os == 'linux-armv7-self-hosted'
+        run: |
+          apt-get update
+
+          # cryptography needs Rust
+          curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain stable -y
+          . $HOME/.cargo/env
+
+          # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
+          apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev -y
+
+          # dbus-python build dependecies
+          apt-get install libtiff5 libjpeg-dev libopenjp2-7 cmake libdbus-1-dev -y
+          apt-get install -y --no-install-recommends python3-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev -y
+          apt-get install -y --no-install-recommends dbus-tests -y
+
+
+      - name: Install additional OS dependencies - Linux ARM64
+        if: matrix.os == 'BrnoRPI-GH004'
+        run: |
+          apt-get update
+
+          # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
+          apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev -y
+
 
       - name: Build wheels for IDF
-        run: python build_wheels.py
+        run: |
+          # Rust directory needs to be included for Linux ARM7
+          if [ "${{ matrix.os }}" == "linux-armv7-self-hosted" ]; then
+            . $HOME/.cargo/env
+          fi
+
+          python build_wheels.py
+
+
+
+
+
+      # - name: Upload Release Asset To test S3 bucket
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      #     AWS_BUCKET: ${{ secrets.DL_BUCKET }}
+      #     PREFIX: 'pypi'
+      #   shell: bash
+      #   run: |
+      #     chmod +x Upload-Wheels.sh
+      #     ./Upload-Wheels.sh $AWS_BUCKET
+      #     pip3 install boto3
+      #     python3 create_index_pages.py $AWS_BUCKET
+
+      # - name: Drop AWS cache
+      #   id: invalidate-index-cache
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      #   run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -1,8 +1,9 @@
 name: platforms-dispatches
 
 on:
-  schedule:
-    - cron: '0 0 * * 0,3'
+  # TODO schedule on final merge
+  #schedule:
+  #  - cron: '0 0 * * 0,3'
   workflow_dispatch:
   pull_request:
 
@@ -11,8 +12,8 @@ env:
   MIN_IDF_MINOR_VERSION: ${{ vars.MIN_IDF_MINOR_VERSION }}
 
 jobs:
-  prepare-environment38:
-    name: Prepare environment for ${{ matrix.os }}
+  build-wheels:
+    name: Build Python wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -74,12 +75,7 @@ jobs:
           python --version
           python -m pip install --upgrade pip
 
-  instal-dependencies:
-    needs: prepare-environment38
-    name: Install dependencies for ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
 
-    steps:
       - name: Install build dependencies
         run: python -m pip install -r build_requirements.txt
 
@@ -122,8 +118,13 @@ jobs:
           apt-get install -y -q --no-install-recommends awscli
 
           # cryptography needs Rust
-          curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain stable -y
-          source $HOME/.cargo/env
+          # clean the container Rust installation to be sure right interpreter is used
+          apt remove --auto-remove --purge rust-gdb rustc libstd-rust-dev libstd-rust-1.48
+          # install Rust dependencies
+          apt-get install -y build-essential libssl-dev libffi-dev python3-dev pkg-config gcc musl-dev
+          # install Rust
+          curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | bash -s -- -y
+          . $HOME/.cargo/env
 
           # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
           apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev -y
@@ -145,18 +146,13 @@ jobs:
           # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
           apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev -y
 
-  build-wheels:
-    needs: instal-dependencies
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
 
-    steps:
       - name: Build wheels for IDF
         if: matrix.os != 'windows-latest'
         run: |
           # Rust directory needs to be included for Linux ARM7
-          if [ "${{ matrix.os }}" == "linux-armv7-self-hosted" ]; then
-            source $HOME/.cargo/env
+          if [ "${{ matrix.os }}" = "linux-armv7-self-hosted" ]; then
+            . $HOME/.cargo/env
           fi
 
           python build_wheels.py
@@ -166,12 +162,10 @@ jobs:
         run: |
           python build_wheels.py
 
-  upload-to-aws:
-    needs: build-wheels
-    name: Upload wheels for ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
 
-    steps:
+      #- name: Build Python version dependendent wheels for IDF
+      #  uses: ./.github/workflows/build-wheels-python-dependent.yml
+
 
       - name: Upload release asset to S3 bucket
         env:

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * 0,3'
   workflow_dispatch:
+  pull_request:
 
 env:
   MIN_IDF_MAJOR_VERSION: ${{ vars.MIN_IDF_MAJOR_VERSION }}
@@ -20,13 +21,13 @@ jobs:
           - windows-latest
           - ubuntu-latest
           - macos-latest
-          - linux-armv7-self-hosted
           - macos-latest-xlarge       # MacOS M1 GitHub beta runner - paid $0.16
-          - BrnoRPI-GH004             # linux ARM64
+          - linux-armv7-self-hosted
+          - linux-arm64-self-hosted
         include:
           - os: linux-armv7-self-hosted
             CONTAINER: python:3.8-bullseye
-          - os: BrnoRPI-GH004
+          - os: linux-arm64-self-hosted
             CONTAINER: python:3.8-bullseye
         python-version: ['3.8']
 
@@ -53,7 +54,7 @@ jobs:
       - name: Setup Python
         # GitHub action for MacOS M1 does not have Python <= 3.10
         # Skip setting python on ARM because of missing compatibility: https://github.com/actions/setup-python/issues/108
-        if: matrix.os != 'macos-latest-xlarge' && matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'BrnoRPI-GH004'
+        if: matrix.os != 'macos-latest-xlarge' && matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'linux-arm64-self-hosted'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -129,7 +130,7 @@ jobs:
 
 
       - name: Install additional OS dependencies - Linux ARM64
-        if: matrix.os == 'BrnoRPI-GH004'
+        if: matrix.os == 'linux-arm64-self-hosted'
         run: |
           apt-get update
 
@@ -156,7 +157,7 @@ jobs:
           python build_wheels.py
 
 
-      - name: Upload Release Asset To test S3 bucket
+      - name: Upload release asset to S3 bucket
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -165,8 +166,7 @@ jobs:
           PREFIX: 'pypi'
         shell: bash
         run: |
-          chmod +x Upload-Wheels.sh
-          ./Upload-Wheels.sh $AWS_BUCKET
+          python upload_wheels.py $AWS_BUCKET
           python create_index_pages.py $AWS_BUCKET
 
 
@@ -177,3 +177,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"
+
+      - name: Remove temporary directory
+        run: rm -r downloaded_wheels

--- a/.github/workflows/build-wheels-python-dependent.yml
+++ b/.github/workflows/build-wheels-python-dependent.yml
@@ -1,0 +1,45 @@
+name: Build Python dependent wheels
+
+on:
+  workflow_call:
+
+jobs:
+  triage:
+    name: Build Python wheels for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+          #- macos-latest-xlarge       # MacOS M1 GitHub beta runner - paid $0.16
+          - linux-armv7-self-hosted
+          - linux-arm64-self-hosted
+        include:
+          - os: linux-armv7-self-hosted
+            CONTAINER: [python:3.9-bullseye, python:3.10-bullseye, python:3.11-bullseye]
+          - os: linux-arm64-self-hosted
+            CONTAINER: [python:3.9-bullseye, python:3.10-bullseye, python:3.11-bullseye]
+        python-version: ['3.9', '3.10', '3.11']
+
+    # Use python container on ARM
+    container: ${{ matrix.CONTAINER }}
+    steps:
+      - name: Setup Python
+        # GitHub action for MacOS M1 does not have Python <= 3.10
+        # Skip setting python on ARM because of missing compatibility: https://github.com/actions/setup-python/issues/108
+        if: matrix.os != 'macos-latest-xlarge' && matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'linux-arm64-self-hosted'
+        uses: actions/setup-python@v4
+        with:
+            python-version: ${{ matrix.python-version }}
+
+      - name: Get Python version
+        run: |
+            python --version
+            python -m pip install --upgrade pip
+
+      - name: Build Python dependent wheels for ${{ matrix.python-version }}
+        run: |
+          python build_wheels_from_file.py

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -11,15 +11,16 @@ env:
 jobs:
   build-python-wheels:
     name: Build Python Wheels for windows-latest
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8.10']
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ['3.8']
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -27,10 +28,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Get Python version
-        run: python --version
+        run: |
+          python --version
+          python -m pip install --upgrade pip
 
       - name: Install build dependencis
-        run: pip install -r .\build_requirements.txt
+        run: pip install -r build_requirements.txt
 
       - name: Build wheels for IDF
-        run: python .\build_wheels.py
+        run: python build_wheels.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
       - id: mixed-line-ending
         args: ['-f=lf']
       - id: double-quote-string-fixer
+      - id: check-yaml
 
   # Replaces flake8
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ This YAML file is converted to Requirement from packaging.requirements because p
 The opposite logic of exclude_list is handled by the function itself, which means it is supposed to be easy to use for developers, this is also the reason YAML format is used.
 
 For every `package_name` there are options:
-* `version` - supports all logic operators defined by PEP508 for versions (<, >, !=, etc.)
+* `version`
+    - supports all logic operators defined by PEP508 for versions (<, >, !=, etc.)
 * `platform`
 
 which could be a string or a list of strings.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,28 @@
 # ESP idf-python-wheels
 
-The goal of this project is to automate build and upload process of required Python Wheels by IDF tools using GitHub Actions. We are able to build wheels for multiple OSes and architectures with multiple versions of Python.
+This project automates the build and upload process of required Python Wheels by [ESP-IDF]. The wheels for multiple OSes and architectures are being built.
 
 Supported architectures:
-* ubuntu-latest - x64
-* macos-latest - x64
-* macos-self-hosted - arm64
-* windows-latest - x64
-* linux-armv7-self-hosted - arm32
-* linux-aarch64-self-hosted - arm64
+* Linux
+    - Ubuntu  - x86_64
+    - ARMv7   - arm32
+    - ARM64
+* Windows     - AMD64
+* MacOS
+    - x86_64
+    - ARM64
 
-Each architecture has it's own workflow in .github/workflows.
+For each `release` branch of [ESP-IDF] starting from the version defined in GitHub variables and [ESP-IDF] `master` branch all the requirements and constraints files are automatically downloaded and wheels are built and uploaded.
 
-For each architecture the user can select Python version to built wheels. On self-hosted runners can handle multiple versions of Python with pyenv.
-
-The build contains all wheels required by branches:
-* release/v4.3
-* release/v4.4
-* master
 
 ## Configuration
-- user can set `IDF_branch` input parameter to add wheels for another branch.
-- currently, it is possible to run a workflow for the whole requirements.txt
-- to add new architecture, set up GitHub runner, and create new GitHub Action
-- workflows need to be started manually
+`MIN_IDF_MAJOR_VERSION` and `MIN_IDF_MINOR_VERSION` GitHub variables can be set in project settings
+to change the [ESP-IDF] `release` branches to build wheels for.
 
 
-## Usage for x64 build
+## Usage of ad-hoc
+Not supported yet.
 
-```
-.\Build-Wheels.ps1 -Branch "master" -Arch "" -CompileWheels @("greenlet", "gevent<2.0,>=1.2.2", "cryptography", "windows-curses", "python-pkcs11") -Python python3.9
-.\Test-Wheels.ps1 -Branch "master"
-```
-
-## Usage for arm64 build
-
-```
-.\Build-Wheels.ps1 -Branch "master" -Arch "-arm64" -CompileWheels @("greenlet", "gevent<2.0,>=1.2.2", "cryptography", "windows-curses", "python-pkcs11") -Python python3.9
-.\Test-Wheels.ps1 -Branch "master"
-```
 
 ## Requirements lists
 These lists are files for requirements that should be added or excluded from the main requirements list which is automatically assembled.
@@ -46,7 +30,7 @@ These lists are files for requirements that should be added or excluded from the
 ### exclude_list.yaml
 File for excluded Python packages in the **main requirements** list.
 
-This YAML file is converted to Requirement from packaging.requirements because pip can handle this format, so the function for converting is designed to be compatible with [PEP508](https://peps.python.org/pep-0508/) scheme.
+This YAML file is converted to `Requirement` from `packaging.requirements` because `pip` can handle this format, so the function for converting is designed to be compatible with [PEP508](https://peps.python.org/pep-0508/) scheme.
 The opposite logic of exclude_list is handled by the function itself, which means it is supposed to be easy to use for developers, this is also the reason YAML format is used.
 
 For every `package_name` there are options:
@@ -85,3 +69,6 @@ The syntax can be also converted into a sentence: "For assembled **main requirem
 
 ### build_requirements.txt
 File for the requirements needed for the build process and the build script.
+
+
+[ESP-IDF]: https://github.com/espressif/esp-idf

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ The opposite logic of exclude_list is handled by the function itself, which mean
 
 For every `package_name` there are options:
 * `version`
-    - supports all logic operators defined by PEP508 for versions (<, >, !=, etc.)
+    - supports all logic operators defined by [PEP508](https://peps.python.org/pep-0508/) for versions (<, >, !=, etc.)
 * `platform`
+* `python`
 
 which could be a string or a list of strings.
 
@@ -45,18 +46,20 @@ exclude_list template:
     - package_name: '<name_of_package>'
         version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
         platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional
+        python: '<python_version_with_operator>' / ['<python_version>', '<python_version>', '<python_version>']                                                     # optional
 
-The syntax can be converted into a sentence: "From assembled **main requirements** exclude `package_name` with `version` on `platform`".
+The syntax can be converted into a sentence: "From assembled **main requirements** exclude `package_name` with `version` on `platform` for `python` version".
 
 example:
 
     - package_name: 'pyserial'
         version: ['>=3.3', '<3.6']
         platform: ['win32', 'linux', 'darwin']
+        python: '>=3.9'
 
-This would mean: "From assembled **main requirements** exclude `pyserial` with version `>=3.3` and `<3.6` on platform `win32`, `linux`, `darwin`".
+This would mean: "From assembled **main requirements** exclude `pyserial` with version `>=3.3` and `<3.6` on platform `win32`, `linux`, `darwin` for `python` version `>=3.9`".
 
-From the example above is clear that the `platform` could be left out (because all main platforms are specified) so the options `platform` or `version` are optional, one of them or both can be not specified and the key can be erased. When only `package_name` is given the package will be excluded from **main requirements**.
+From the example above is clear that the `platform` could be left out (because all main platforms are specified) so the options `platform` or `version` or `python` are optional, one of them or both can be not specified and the key can be erased. When only `package_name` is given the package will be excluded from **main requirements**.
 
 
 ### include_list.yaml
@@ -64,7 +67,7 @@ File for additional Python packages to the **main requirements** list. Built sep
 
 This YAML file uses the same mechanism such as **exclude_list** but without the opposite logic.
 
-The syntax can be also converted into a sentence: "For assembled **main requirements** additionally include `package_name` with `version` on `platform`".
+The syntax can be also converted into a sentence: "For assembled **main requirements** additionally include `package_name` with `version` on `platform` for `python` version".
 
 
 ### build_requirements.txt

--- a/README.md
+++ b/README.md
@@ -43,11 +43,44 @@ The build contains all wheels required by branches:
 ## Requirements lists
 These lists are files for requirements that should be added or excluded from the main requirements list which is automatically assembled.
 
-### include_list
-File for additional Python packages to the main requirements list. Built separately to not restrict the main requirements list.
+### exclude_list.yaml
+File for excluded Python packages in the **main requirements** list.
 
-### exclude_list
-File for excluded Python packages in the main requirements list.
+This YAML file is converted to Requirement from packaging.requirements because pip can handle this format, so the function for converting is designed to be compatible with [PEP508](https://peps.python.org/pep-0508/) scheme.
+The opposite logic of exclude_list is handled by the function itself, which means it is supposed to be easy to use for developers, this is also the reason YAML format is used.
+
+For every `package_name` there are options:
+* `version` - supports all logic operators defined by PEP508 for versions (<, >, !=, etc.)
+* `platform`
+
+which could be a string or a list of strings.
+
+exclude_list template:
+
+    - package_name: '<name_of_package>'
+        version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
+        platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional
+
+The syntax can be converted into a sentence: "From assembled **main requirements** exclude `package_name` with `version` on `platform`".
+
+example:
+
+    - package_name: 'pyserial'
+        version: ['>=3.3', '<3.6']
+        platform: ['win32', 'linux', 'darwin']
+
+This would mean: "From assembled **main requirements** exclude `pyserial` with version `>=3.3` and `<3.6` on platform `win32`, `linux`, `darwin`".
+
+From the example above is clear that the `platform` could be left out (because all main platforms are specified) so the options `platform` or `version` are optional, one of them or both can be not specified and the key can be erased. When only `package_name` is given the package will be excluded from **main requirements**.
+
+
+### include_list.yaml
+File for additional Python packages to the **main requirements** list. Built separately to not restrict the **main requirements** list.
+
+This YAML file uses the same mechanism such as **exclude_list** but without the opposite logic.
+
+The syntax can be also converted into a sentence: "For assembled **main requirements** additionally include `package_name` with `version` on `platform`".
+
 
 ### build_requirements.txt
 File for the requirements needed for the build process and the build script.

--- a/Upload-Wheels.sh
+++ b/Upload-Wheels.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd download || exit
+cd downloaded_wheels || exit
 
 for wfile in *.whl; do
   file_name=$(echo "${wfile%%-*}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')

--- a/Upload-Wheels.sh
+++ b/Upload-Wheels.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd downloaded_wheels || exit
+cd download || exit
 
 for wfile in *.whl; do
   file_name=$(echo "${wfile%%-*}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -4,3 +4,4 @@ requests
 packaging
 PyYAML
 colorama
+boto3

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,7 +1,8 @@
 # This is a list of Python packages needed for build process and script. This file is used with pip.
 # ----- build script -----
-requests
-packaging
-PyYAML
-colorama
-boto3
+requests~=2.31.0
+packaging~=23.2
+PyYAML~=6.0.1
+colorama~=0.4.6
+# ----- build process -----
+boto3~=1.34.4

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -2,3 +2,5 @@
 # ----- build script -----
 requests
 packaging
+PyYAML
+colorama

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -138,7 +138,7 @@ def _download_branch_constraints(constraint_file_url: str, branch, idf_constrain
     return []
 
 
-def _add_into_requirements(requirements_txt: List[str]) -> set[Union[Requirement, str]]:
+def _add_into_requirements(requirements_txt: List[str]) -> set:
     """Create set of requirements from downloaded lines of requirements
         - set is used to prevent duplicates
     """
@@ -155,7 +155,7 @@ def _add_into_requirements(requirements_txt: List[str]) -> set[Union[Requirement
     return requirements_set
 
 
-def assemble_requirements(idf_branches: List[str], idf_constraints: List[str]) -> set[Union[Requirement, str]]:
+def assemble_requirements(idf_branches: List[str], idf_constraints: List[str]) -> set:
     """Assemble IDF requirements into set to prevent duplicates"""
     requirements_txt: List[str] = []
 
@@ -175,7 +175,7 @@ def assemble_requirements(idf_branches: List[str], idf_constraints: List[str]) -
     return _add_into_requirements(requirements_txt)
 
 
-def print_requirements(requirements_set: set[Union[Requirement, str]]):
+def print_requirements(requirements_set: set):
     """Prints assembled list of requirements"""
     print('\n---------- REQUIREMENTS ----------')
     for req in requirements_set:

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -1,3 +1,8 @@
+#
+# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 import json
 import os
 import re

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -1,11 +1,15 @@
 import json
 import os
 import re
+import subprocess
 from typing import List
 from typing import Optional
 from typing import Union
 
 import requests
+import yaml
+from colorama import Fore
+from colorama import Style
 from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
 
@@ -117,7 +121,7 @@ def get_constraints_versions(idf_branches: List[str]) -> List[str]:
 # --- Download all requirements from all the branches requirements and constraints files --- #
 def _download_branch_requirements(branch: str, idf_requirements_json: dict) -> List[str]:
     """Download requirements files for all groups specified in IDF requirements.JSON"""
-    print(f'---------- ESP-IDF BRANCH {branch} ----------')
+    print(Fore.BLUE + f'---------- ESP-IDF BRANCH {branch} ----------' + Style.RESET_ALL)
     requirements_txt: List[str] = []
 
     for feature in idf_requirements_json['features']:
@@ -138,6 +142,7 @@ def _download_branch_constraints(constraint_file_url: str, branch, idf_constrain
     return []
 
 
+non_classic_requirement:List[str] = []
 def _add_into_requirements(requirements_txt: List[str]) -> set:
     """Create set of requirements from downloaded lines of requirements
         - set is used to prevent duplicates
@@ -150,12 +155,12 @@ def _add_into_requirements(requirements_txt: List[str]) -> set:
             try:
                 requirements_set.add(Requirement(line))
             except InvalidRequirement:
-                # TODO not a classic requirement (e.g. '--only-binary cryptography') when building wheels
-                requirements_set.add(line)
+                # Non classic requirement (e.g. '--only-binary cryptography')
+                non_classic_requirement.append(line)
     return requirements_set
 
 
-def assemble_requirements(idf_branches: List[str], idf_constraints: List[str]) -> set:
+def assemble_requirements(idf_branches: List[str], idf_constraints: List[str], make_txt_file:bool=False) -> set:
     """Assemble IDF requirements into set to prevent duplicates"""
     requirements_txt: List[str] = []
 
@@ -172,18 +177,176 @@ def assemble_requirements(idf_branches: List[str], idf_constraints: List[str]) -
         requirements_txt += _download_branch_requirements(branch, idf_requirements_json)
         requirements_txt += _download_branch_constraints(constraint_file_url, branch, idf_constraints[i])
 
+    if make_txt_file:
+        # TXT file from all downloaded requirements and constraints files
+        # useful for debugging or to see the comments for requirements
+        with open('requirements.txt', 'w') as f:
+            for line in requirements_txt:
+                f.write(line)
+                f.write('\n')
+
     return _add_into_requirements(requirements_txt)
 
 
-def print_requirements(requirements_set: set):
-    """Prints assembled list of requirements"""
-    print('\n---------- REQUIREMENTS ----------')
-    for req in requirements_set:
-        print(req)
+# --- exclude_list and include_list ---
+def _change_specifier_logic(specifier: str) -> str:
+    """Change specifier logic to opposite
+        - e.g. "<3" will be ">3"
+    """
+    #print(f"Original specifier: {specifier}")
+    new_spec = specifier
+    replacements = {'<': '>',
+                    '>': '<',
+                    '!': '=',
+                    '==': '!='}
+    for old, new in replacements.items():
+        if old in specifier and '===' not in specifier:
+            new_spec = specifier.replace(old, new)
+    #print(f"Specifier changed: {new_spec}")
+    return new_spec
+
+
+def yaml_to_requirement(yaml_file:str, exclude: bool = False) -> set:
+    """Converts YAML defined package into packaging.requirements Requirement
+    which can be directly used with pip
+    - when exclude is set to True it makes opposite logic for Requirement to be excluded"""
+    with open(yaml_file, 'r') as f:
+        yaml_list = yaml.load(f, yaml.Loader)
+
+    exclude_list_set: set[Requirement] = set()
+
+    if not yaml_list:
+        return exclude_list_set
+
+    for package in yaml_list:
+        req_txt = f"{package['package_name']}"
+
+        if 'version' in package:
+            if isinstance(package['version'], list):
+                ver_txt = ''
+                for ver_str in package['version']:
+                    if exclude:
+                        ver_txt += f'{_change_specifier_logic(ver_str)},'
+                    else:
+                        ver_txt += f'{ver_str},'
+                req_txt += ver_txt[:-1]
+            else:
+                if exclude:
+                    req_txt += _change_specifier_logic(package['version'])
+                else:
+                    req_txt += package['version']
+
+        if 'platform' in package:
+            if isinstance(package['platform'], list):
+                plf_txt = '; '
+                for plf_str in package['platform']:
+                    if exclude:
+                        plf_txt += f"sys_platform != '{plf_str}' or "
+                    else:
+                        plf_txt += f"sys_platform == '{plf_str}' or "
+                req_txt += plf_txt[:-4]
+            else:
+                if exclude:
+                    req_txt += f"; sys_platform != '{package['platform']}'"
+                else:
+                    req_txt += f"; sys_platform == '{package['platform']}'"
+
+        exclude_list_set.add(Requirement(req_txt))
+    return exclude_list_set
+
+
+def exclude_from_requirements(assembled_requirements:set, exclude_list: set, print_requirements: bool = True) -> set:
+    """Exclude packages defined in exclude_list from assembled requirements
+        - print_requirements = true will print the changes
+    """
+    new_assembled_requirements = set()
+    not_in_exclude = []
+    if print_requirements:
+        print(Fore.BLUE + '---------- REQUIREMENTS ----------')
+
+    for requirement in assembled_requirements:
+        for req in exclude_list:
+            if req.name in requirement.name:
+
+                if requirement.specifier and req.specifier:
+                    new_specifier = requirement.specifier & req.specifier
+                elif requirement.specifier and not req.specifier:
+                    new_specifier = requirement.specifier
+                elif not requirement.specifier and req.specifier:
+                    new_specifier = req.specifier
+                else:
+                    new_specifier = ''
+
+                if requirement.marker and req.marker:
+                    new_markers = f'({requirement.marker}) and ({req.marker})'
+                elif requirement.marker and not req.marker:
+                    new_markers = requirement.marker
+                elif not requirement.marker and req.marker:
+                    new_markers = req.marker
+                else:
+                    new_markers = ''
+
+                if not req.specifier and not req.marker:
+                    if print_requirements:
+                        print(Fore.RED + f'-- {requirement}')
+                    continue
+
+                if new_markers:
+                    new_requirement = Requirement(f'{requirement.name}{new_specifier}; {new_markers}')
+                else:
+                    new_requirement = Requirement(f'{requirement.name}{new_specifier}')
+
+                new_assembled_requirements.add(new_requirement)
+
+                if print_requirements:
+                    print(Fore.RED + f'-- {requirement}')
+                    print(Fore.GREEN + f'++ {new_requirement}')
+            else:
+                not_in_exclude.append(True)
+        if len(not_in_exclude) == len(exclude_list):
+            if print_requirements:
+                print(Style.RESET_ALL + str(requirement))
+            new_assembled_requirements.add(requirement)
+
+        not_in_exclude = []
+
+    if print_requirements:
+        print(Fore.BLUE + '---------- END OF REQUIREMENTS ----------' + Style.RESET_ALL)
+
+    return new_assembled_requirements
+
+
+# --- Build wheels ---
+def build_wheels(requirements: set):
+    """Build Python wheels"""
+    dir = f'{os.path.curdir}{(os.sep)}downloaded_wheels'
+    for requirement in requirements:
+        # --only-binary requirement wheel build
+        if non_classic_requirement and non_classic_requirement[0].replace('--only-binary ', '') in requirement.name:
+            only_bin = non_classic_requirement[0].replace('--only-binary', '').strip()
+            var = subprocess.run(
+                ['python', '-m', 'pip', 'wheel', f'{requirement}', '--find-links', f'{dir}',
+                 '--wheel-dir', f'{dir}', '--only-binary', f'{only_bin}'],
+                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                )
+            print(f'Ret_code: {str(var.returncode)}, std_err: {str(var.stderr)}, std_out: {str(var.stdout)}')
+
+            non_classic_requirement.remove(non_classic_requirement[0])
+            continue
+
+        # requirement wheel build
+        var = subprocess.run(
+            ['python', '-m', 'pip', 'wheel', f'{requirement}', '--find-links', f'{dir}',
+             '--wheel-dir', f'{dir}'],
+             stdout=subprocess.PIPE, stderr=subprocess.PIPE
+             )
+        print(f'Ret_code: {str(var.returncode)}, std_err: {str(var.stderr)}, std_out: {str(var.stdout)}')
 
 
 def main():
-    """Builds Python wheels for IDF dependencies"""
+    """Builds Python wheels for ESP-IDF dependencies for master and release branches
+    grater or equal to specified"""
+
     idf_repo_branches = fetch_idf_branches()
     idf_branches = get_used_idf_branches(idf_repo_branches)
     print(f'ESP-IDF branches to be downloaded requirements for:\n{idf_branches}\n')
@@ -191,9 +354,20 @@ def main():
     idf_constraints = get_constraints_versions(idf_branches)
     print(f'ESP-IDF constrains files versions to be downloaded requirements for:\n{idf_constraints}\n')
 
-    requirements_set = assemble_requirements(idf_branches, idf_constraints)
+    requirements = assemble_requirements(idf_branches, idf_constraints)
 
-    print_requirements(requirements_set)
+    exclude_list = yaml_to_requirement('exclude_list.yaml', exclude=True)
+    excluded_requirements = exclude_from_requirements(requirements, exclude_list)
+
+    include_list = yaml_to_requirement('include_list.yaml')
+    print(Fore.BLUE + '---------- ADDITIONAL REQUIREMENTS ----------' + Style.RESET_ALL)
+    for req in include_list:
+        print(req)
+    print(Fore.BLUE + '---------- END OF ADDITIONAL REQUIREMENTS ----------' + Style.RESET_ALL)
+
+    build_wheels(excluded_requirements)
+
+    build_wheels(include_list)
 
 
 if __name__ == '__main__':

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -324,23 +324,22 @@ def build_wheels(requirements: set):
         # --only-binary requirement wheel build
         if non_classic_requirement and non_classic_requirement[0].replace('--only-binary ', '') in requirement.name:
             only_bin = non_classic_requirement[0].replace('--only-binary', '').strip()
-            var = subprocess.run(
+            out = subprocess.run(
                 ['python', '-m', 'pip', 'wheel', f'{requirement}', '--find-links', f'{dir}',
                  '--wheel-dir', f'{dir}', '--only-binary', f'{only_bin}'],
                  stdout=subprocess.PIPE, stderr=subprocess.PIPE
                 )
-            print(f'Ret_code: {str(var.returncode)}, std_err: {str(var.stderr)}, std_out: {str(var.stdout)}')
-
+            print(out.stdout, out.stderr)
             non_classic_requirement.remove(non_classic_requirement[0])
             continue
 
         # requirement wheel build
-        var = subprocess.run(
+        out = subprocess.run(
             ['python', '-m', 'pip', 'wheel', f'{requirement}', '--find-links', f'{dir}',
              '--wheel-dir', f'{dir}'],
              stdout=subprocess.PIPE, stderr=subprocess.PIPE
              )
-        print(f'Ret_code: {str(var.returncode)}, std_err: {str(var.stderr)}, std_out: {str(var.stdout)}')
+        print(out.stdout, out.stderr)
 
 
 def main():
@@ -365,8 +364,10 @@ def main():
         print(req)
     print(Fore.BLUE + '---------- END OF ADDITIONAL REQUIREMENTS ----------' + Style.RESET_ALL)
 
+    print(Fore.BLUE + '---------- BUILD WHEELS ----------' + Style.RESET_ALL)
     build_wheels(excluded_requirements)
 
+    print(Fore.BLUE + '---------- BUILD ADDITIONAL WHEELS ----------' + Style.RESET_ALL)
     build_wheels(include_list)
 
 

--- a/build_wheels_from_file.py
+++ b/build_wheels_from_file.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+
+failed_wheels = 0
+succeeded_wheels = 0
+
+with open('dependent_requirements.txt', 'r') as f:
+    requirements = f.readlines()
+
+for requirement in requirements:
+    out = subprocess.run(
+            [f'{sys.executable}', '-m', 'pip', 'wheel', f'{requirement}',
+             '--find-links', 'downloaded_wheels', '--wheel-dir', 'downloaded_wheels'],
+             stdout=subprocess.PIPE, stderr=subprocess.PIPE
+             )
+
+    print(out.stdout.decode('utf-8'))
+    if out.stderr:
+        print(out.stderr.decode('utf-8'))
+
+    if out.returncode != 0:
+        failed_wheels += 1
+    else:
+        succeeded_wheels += 1
+
+
+print('---------- STATISTICS ----------')
+print(f'Succeeded {succeeded_wheels} wheels')
+print(f'Failed {failed_wheels} wheels')

--- a/build_wheels_from_file.py
+++ b/build_wheels_from_file.py
@@ -1,3 +1,8 @@
+#
+# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 import subprocess
 import sys
 

--- a/exclude_list.yaml
+++ b/exclude_list.yaml
@@ -1,0 +1,11 @@
+# List of Python packages to exclude from automatically assembled requirements
+#"From assembled <main requirements> exclude <package_name> with <version> on <platform>".
+
+# exclude_list template
+#- package_name: '<name_of_package>'
+#    version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
+#    platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional
+
+# dbus-python can not be build on Windows
+- package_name: 'dbus-python'
+  platform: ['win32']

--- a/exclude_list.yaml
+++ b/exclude_list.yaml
@@ -5,6 +5,7 @@
 #- package_name: '<name_of_package>'
 #    version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
 #    platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional
+#    python: '<python_version_with_operator>' / ['<python_version>', '<python_version>', '<python_version>']                 # optional
 
 # dbus-python can not be build on Windows
 - package_name: 'dbus-python'

--- a/include_list.yaml
+++ b/include_list.yaml
@@ -5,3 +5,6 @@
 #- package_name: '<name_of_package>'
 #    version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
 #    platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional
+
+- package_name: 'cython'
+  version: '<3'

--- a/include_list.yaml
+++ b/include_list.yaml
@@ -5,6 +5,3 @@
 #- package_name: '<name_of_package>'
 #    version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
 #    platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional
-
-- package_name: 'cython'
-  version: '<3'

--- a/include_list.yaml
+++ b/include_list.yaml
@@ -1,0 +1,7 @@
+# List of Python packages to additionally include to the automatically assembled requirements
+#"For assembled <main requirements> additionally include <package_name> with <version> on <platform>".
+
+# include_list template
+#- package_name: '<name_of_package>'
+#    version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
+#    platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional

--- a/include_list.yaml
+++ b/include_list.yaml
@@ -5,3 +5,9 @@
 #- package_name: '<name_of_package>'
 #    version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
 #    platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional
+
+# lxml is missing as a dependency of pytest-embedded
+# https://github.com/espressif/pytest-embedded/blob/main/pyproject.toml
+# According to PEP518 when the pyproject.toml is preset the build system uses it
+- package_name: 'lxml'
+  version: '~=4.9.3'

--- a/include_list.yaml
+++ b/include_list.yaml
@@ -6,9 +6,3 @@
 #    version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
 #    platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional
 #    python: '<python_version_with_operator>' / ['<python_version>', '<python_version>', '<python_version>']                 # optional
-
-# lxml is missing as a dependency of pytest-embedded
-# https://github.com/espressif/pytest-embedded/blob/main/pyproject.toml
-# According to PEP518 when the pyproject.toml is preset the build system uses it
-- package_name: 'lxml'
-  version: '~=4.9.3'

--- a/include_list.yaml
+++ b/include_list.yaml
@@ -5,6 +5,7 @@
 #- package_name: '<name_of_package>'
 #    version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
 #    platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional
+#    python: '<python_version_with_operator>' / ['<python_version>', '<python_version>', '<python_version>']                 # optional
 
 # lxml is missing as a dependency of pytest-embedded
 # https://github.com/espressif/pytest-embedded/blob/main/pyproject.toml

--- a/test/test_list.yaml
+++ b/test/test_list.yaml
@@ -1,0 +1,107 @@
+# List of Python packages for testing
+# platform
+- package_name: 'platform'
+  platform: 'win32'
+
+- package_name: 'platform'
+  platform: ['win32', 'linux']
+# version
+- package_name: 'version'
+  version: '<42'
+
+- package_name: 'version'
+  version: ['<42', '>50']
+# Python
+- package_name: 'python'
+  python: '>3.10'
+
+- package_name: 'python'
+  python: ['>3.10', '!=3.8']
+# version and platform
+- package_name: 'version-platform'
+  version: '<=0.9.0.2'
+  platform: 'win32'
+
+- package_name: 'version-platform'
+  version: ['<=0.9.0.2', '>0.9.1']
+  platform: 'win32'
+
+- package_name: 'version-platform'
+  version: '<=0.9.0.2'
+  platform: ['win32', 'linux']
+
+- package_name: 'version-platform'
+  version: ['<=0.9.0.2', '>0.9.1']
+  platform: ['win32', 'linux']
+# version and Python
+- package_name: 'version-python'
+  version: '<=0.9.0.2'
+  python: '<3.8'
+
+- package_name: 'version-python'
+  version: ['<=0.9.0.2', '>0.9.1']
+  python: '<3.8'
+
+- package_name: 'version-python'
+  version: '<=0.9.0.2'
+  python: ['<3.8', '>3.11']
+
+- package_name: 'version-python'
+  version: ['<=0.9.0.2', '>0.9.1']
+  python: ['<3.8', '>3.11']
+# platform and Python
+- package_name: 'platform-python'
+  platform: 'win32'
+  python: '<3.8'
+
+- package_name: 'platform-python'
+  platform: ['win32', 'linux']
+  python: '<3.8'
+
+- package_name: 'platform-python'
+  platform: 'win32'
+  python: ['<3.8', '>3.11']
+
+- package_name: 'platform-python'
+  platform: ['win32', 'linux']
+  python: ['<3.8', '>3.11']
+# version and platform and Python
+- package_name: 'version-platform-python'
+  version: '<=0.9.0.2'
+  platform: 'win32'
+  python: '<3.8'
+
+- package_name: 'version-platform-python'
+  version: ['<=0.9.0.2', '>0.9.1']
+  platform: 'win32'
+  python: '<3.8'
+
+- package_name: 'version-platform-python'
+  version: ['<=0.9.0.2', '>0.9.1']
+  platform: ['win32', 'linux']
+  python: '<3.8'
+
+- package_name: 'version-platform-python'
+  version: '<=0.9.0.2'
+  platform: ['win32', 'linux']
+  python: '<3.8'
+
+- package_name: 'version-platform-python'
+  version: '<=0.9.0.2'
+  platform: 'win32'
+  python: ['<3.8', '>3.11']
+
+- package_name: 'version-platform-python'
+  version: ['<=0.9.0.2', '>0.9.1']
+  platform: 'win32'
+  python: ['<3.8', '>3.11']
+
+- package_name: 'version-platform-python'
+  version: ['<=0.9.0.2', '>0.9.1']
+  platform: ['win32', 'linux']
+  python: ['<3.8', '>3.11']
+
+- package_name: 'version-platform-python'
+  version: '<=0.9.0.2'
+  platform: ['win32', 'linux']
+  python: ['<3.8', '>3.11']

--- a/test_build_wheels.py
+++ b/test_build_wheels.py
@@ -1,0 +1,107 @@
+# ruff: noqa: E501
+# line too long skip in ruff for whole file (formatting would be worst than long lines)
+import unittest
+
+from packaging.requirements import Requirement
+
+from build_wheels import _change_specifier_logic
+from build_wheels import yaml_to_requirement
+
+
+class TestYAMLtoRequirement(unittest.TestCase):
+
+    def test_change_specifier_logic(self):
+        version_with_specifier = (('>0.9.0.2', '<0.9.0.2'),
+                                  ('<0.9.0.2', '>0.9.0.2'),
+                                  ('==0.9.0.2', '!=0.9.0.2'),
+                                  ('>=0.9.0.2', '<=0.9.0.2'),
+                                  ('<=0.9.0.2', '>=0.9.0.2'),
+                                  ('!=0.9.0.2', '==0.9.0.2'),
+                                  ('===0.9.0.2', '===0.9.0.2'),
+                                )
+
+        for case in version_with_specifier:
+            self.assertEqual(f'{_change_specifier_logic(case[0])[0]}{_change_specifier_logic(case[0])[1]}', case[1])
+
+    def test_yaml_to_requirement(self):
+        test_requirements = {Requirement("platform;sys_platform == 'win32'"),
+                             Requirement("platform;sys_platform == 'win32' or sys_platform == 'linux'"),
+                             Requirement('version<42'),
+                             Requirement('version<42,>50'),
+                             Requirement("python;python_version > '3.10'"),
+                             Requirement("python;python_version > '3.10' and python_version != '3.8'"),
+                             Requirement("version-platform<=0.9.0.2;sys_platform == 'win32'"),
+                             Requirement("version-platform<=0.9.0.2,>0.9.1;sys_platform == 'win32'"),
+                             Requirement("version-platform<=0.9.0.2;sys_platform == 'win32' or sys_platform == 'linux'"),
+                             Requirement("version-platform<=0.9.0.2,>0.9.1;sys_platform == 'win32' or sys_platform == 'linux'"),
+                             Requirement("version-python<=0.9.0.2;python_version < '3.8'"),
+                             Requirement("version-python<=0.9.0.2,>0.9.1;python_version < '3.8'"),
+                             Requirement("version-python<=0.9.0.2;python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-python<=0.9.0.2,>0.9.1;python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("platform-python;sys_platform == 'win32' and python_version < '3.8'"),
+                             Requirement("platform-python;sys_platform == 'win32' or sys_platform == 'linux' and python_version < '3.8'"),
+                             Requirement("platform-python;sys_platform == 'win32' and python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("platform-python;sys_platform == 'win32' or sys_platform == 'linux' and python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-platform-python<=0.9.0.2;sys_platform == 'win32' and python_version < '3.8'"),
+                             Requirement("version-platform-python<=0.9.0.2,>0.9.1;sys_platform == 'win32' and python_version < '3.8'"),
+                             Requirement("version-platform-python<=0.9.0.2,>0.9.1;sys_platform == 'win32' or sys_platform == 'linux' and python_version < '3.8'"),
+                             Requirement("version-platform-python<=0.9.0.2;sys_platform == 'win32' or sys_platform == 'linux' and python_version < '3.8'"),
+                             Requirement("version-platform-python<=0.9.0.2;sys_platform == 'win32' and python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-platform-python<=0.9.0.2,>0.9.1;sys_platform == 'win32' and python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-platform-python<=0.9.0.2,>0.9.1;sys_platform == 'win32' or sys_platform == 'linux' and python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-platform-python<=0.9.0.2;sys_platform == 'win32' or sys_platform == 'linux' and python_version < '3.8' and python_version > '3.11'"),
+        }
+
+        self.assertEqual(yaml_to_requirement('test/test_list.yaml'), test_requirements)
+
+
+    def test_yaml_to_requirement_exclude(self):
+        test_requirements_exclude = {Requirement("platform;sys_platform != 'win32'"),
+                             Requirement("platform;sys_platform != 'win32' or sys_platform != 'linux'"),
+                             Requirement('version>42'),
+                             Requirement('version>42,<50'),
+                             Requirement("python;python_version < '3.10'"),
+                             Requirement("python;python_version < '3.10' and python_version == '3.8'"),
+                             Requirement("version-platform>=0.9.0.2;sys_platform == 'win32'"),
+                             Requirement("version-platform;sys_platform != 'win32'"),
+                             Requirement("version-platform>=0.9.0.2,<0.9.1;sys_platform == 'win32'"),
+                             Requirement("version-platform;sys_platform != 'win32'"),
+                             Requirement("version-platform>=0.9.0.2;sys_platform == 'win32' or sys_platform == 'linux'"),
+                             Requirement("version-platform;sys_platform != 'win32' or sys_platform != 'linux'"),
+                             Requirement("version-platform>=0.9.0.2,<0.9.1;sys_platform == 'win32' or sys_platform == 'linux'"),
+                             Requirement("version-platform;sys_platform != 'win32' or sys_platform != 'linux'"),
+                             Requirement("version-python>=0.9.0.2;python_version < '3.8'"),
+                             Requirement("version-python;python_version > '3.8'"),
+                             Requirement("version-python>=0.9.0.2,<0.9.1;python_version < '3.8'"),
+                             Requirement("version-python;python_version > '3.8'"),
+                             Requirement("version-python>=0.9.0.2;python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-python;python_version > '3.8' and python_version < '3.11'"),
+                             Requirement("version-python>=0.9.0.2,<0.9.1;python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-python;python_version > '3.8' and python_version < '3.11'"),
+                             Requirement("platform-python;sys_platform != 'win32' and python_version > '3.8'"),
+                             Requirement("platform-python;sys_platform != 'win32' or sys_platform != 'linux' and python_version > '3.8'"),
+                             Requirement("platform-python;sys_platform != 'win32' and python_version > '3.8' and python_version < '3.11'"),
+                             Requirement("platform-python;sys_platform != 'win32' or sys_platform != 'linux' and python_version > '3.8' and python_version < '3.11'"),
+                             Requirement("version-platform-python>=0.9.0.2;sys_platform == 'win32' and python_version < '3.8'"),
+                             Requirement("version-platform-python;sys_platform != 'win32' and python_version > '3.8'"),
+                             Requirement("version-platform-python>=0.9.0.2,<0.9.1;sys_platform == 'win32' and python_version < '3.8'"),
+                             Requirement("version-platform-python;sys_platform != 'win32' and python_version > '3.8'"),
+                             Requirement("version-platform-python>=0.9.0.2,<0.9.1;sys_platform == 'win32' or sys_platform == 'linux' and python_version < '3.8'"),
+                             Requirement("version-platform-python;sys_platform != 'win32' or sys_platform != 'linux' and python_version > '3.8'"),
+                             Requirement("version-platform-python>=0.9.0.2;sys_platform == 'win32' or sys_platform == 'linux' and python_version < '3.8'"),
+                             Requirement("version-platform-python;sys_platform != 'win32' or sys_platform != 'linux' and python_version > '3.8'"),
+                             Requirement("version-platform-python>=0.9.0.2;sys_platform == 'win32' and python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-platform-python;sys_platform != 'win32' and python_version > '3.8' and python_version < '3.11'"),
+                             Requirement("version-platform-python>=0.9.0.2,<0.9.1;sys_platform == 'win32' and python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-platform-python;sys_platform != 'win32' and python_version > '3.8' and python_version < '3.11'"),
+                             Requirement("version-platform-python>=0.9.0.2,<0.9.1;sys_platform == 'win32' or sys_platform == 'linux' and python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-platform-python;sys_platform != 'win32' or sys_platform != 'linux' and python_version > '3.8' and python_version < '3.11'"),
+                             Requirement("version-platform-python>=0.9.0.2;sys_platform == 'win32' or sys_platform == 'linux' and python_version < '3.8' and python_version > '3.11'"),
+                             Requirement("version-platform-python;sys_platform != 'win32' or sys_platform != 'linux' and python_version > '3.8' and python_version < '3.11'"),
+        }
+
+        self.assertEqual(yaml_to_requirement('test/test_list.yaml', exclude=True), test_requirements_exclude)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_build_wheels.py
+++ b/test_build_wheels.py
@@ -1,5 +1,10 @@
 # ruff: noqa: E501
 # line too long skip in ruff for whole file (formatting would be worst than long lines)
+#
+# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 import unittest
 
 from packaging.requirements import Requirement

--- a/upload_wheels.py
+++ b/upload_wheels.py
@@ -1,0 +1,36 @@
+"""This script uploads wheel files from the downloaded wheels directory to S3 bucket.
+    - argument S3 bucket
+"""
+import os
+import re
+import sys
+
+import boto3
+
+
+s3 = boto3.resource('s3')
+try:
+    BUCKET = s3.Bucket(sys.argv[1])
+except IndexError:
+    raise SystemExit('Error: S3 bucket name not provided.')
+
+WHEELS_DIR = f'{os.path.curdir}{(os.sep)}downloaded_wheels'
+if not os.path.exists(WHEELS_DIR):
+    raise SystemExit(f'Error: The wheels directory {WHEELS_DIR} not found.')
+
+wheel_files = os.listdir(WHEELS_DIR)
+
+for wheel in wheel_files:
+    pattern = re.compile(r'([^ -]*)-(\d+)')
+    match = pattern.search(wheel)
+    if match:
+        wheel_name = match.group(1)
+
+    wheel_name = wheel_name.lower()
+    wheel_name = wheel_name.replace('_', '-')
+
+    if sys.platform in 'CYGWIN,MINGW,MINGW32,MSYS' and wheel_name == 'esptool':
+        continue
+
+    BUCKET.upload_file(f'{WHEELS_DIR}{os.sep}{wheel}', f'pypi/{wheel_name}/{wheel}')
+    print(f'Uploaded {wheel}')

--- a/upload_wheels.py
+++ b/upload_wheels.py
@@ -1,3 +1,8 @@
+#
+# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 """This script uploads wheel files from the downloaded wheels directory to S3 bucket.
     - argument S3 bucket
 """
@@ -21,16 +26,13 @@ if not os.path.exists(WHEELS_DIR):
 wheel_files = os.listdir(WHEELS_DIR)
 
 for wheel in wheel_files:
-    pattern = re.compile(r'([^ -]*)-(\d+)')
+    pattern = re.compile(r'(\w*)-(\d+)')
     match = pattern.search(wheel)
     if match:
         wheel_name = match.group(1)
 
     wheel_name = wheel_name.lower()
     wheel_name = wheel_name.replace('_', '-')
-
-    if sys.platform in 'CYGWIN,MINGW,MINGW32,MSYS' and wheel_name == 'esptool':
-        continue
 
     BUCKET.upload_file(f'{WHEELS_DIR}{os.sep}{wheel}', f'pypi/{wheel_name}/{wheel}')
     print(f'Uploaded {wheel}')


### PR DESCRIPTION
- Added `include_list` and `exclude_list` for additional Python packages or temporary workaround
    - **clear prints of changes to assembled requirements**
- Edited `README.md`
    - refactor 
    - explanation of usage `exclude_list`/`include_list`
- Changed workflow name and extended it for every platform
    - One workflow file, is used for all platforms instead of separated files for platforms
- Added wheels build
- Converted upload of wheels to Python script
- Added Python version option into yaml file

[workflow run](https://github.com/espressif/idf-python-wheels/actions/runs/7142131695/job/19450764972?pr=21) under "Build wheels for IDF" job step is clear output of what requirements are downloaded and what changes have been done after applying requirements from `exclude_list` and `include_list`
    - MacOS M1 architecture is missing because of paid runner to not waste GitHub Actions spending limit ([M1 workflow](https://github.com/espressif/idf-python-wheels/actions/runs/6971282866/job/18970992725))
    
   Following steps:
   - Make ad-hoc work (manual specification of requirement/s to be build and upload wheels for)
   - Clean up the repository
   - Migrate and change default branch to `master` ?