### PR TITLE
feat: Python version dependent wheels build

### DIFF
--- a/.github/workflows/build-wheels-defined.yml
+++ b/.github/workflows/build-wheels-defined.yml
@@ -1,0 +1,279 @@
+name: defined-wheels
+on:
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: >
+          Generate wheels for given packages separated by space.
+          Requirement specifiers and markers can be used.
+          For example esptool~=4.5 esp-coredump~=1.2;sys_platform!='win32'
+        type: string
+        required: true
+
+      os_ubuntu_latest:
+        description: Build on ubuntu-latest(x86_64)
+        type: boolean
+        required: false
+        default: true
+      os_windows_latest:
+        description: Build on windows-latest(x86_64)
+        type: boolean
+        required: false
+        default: true
+      os_macos_latest:
+        description: Build on macos-latest(x86_64)
+        type: boolean
+        required: false
+        default: true
+      os_macos_arm64:
+        description: Build on macos M1(aarch64)
+        type: boolean
+        required: false
+        default: true
+      os_linux_armv7:
+        description: Build on linux armv7(aarch32)
+        type: boolean
+        required: false
+        default: true
+      os_linux_arm64:
+        description: Build on linux arm64(aarch64)
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+  ubuntu-latest:
+    name: linux x86_64
+    if: ${{ inputs.os_ubuntu_latest }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version}}
+
+      - name: Get Python version
+        run: |
+          python --version
+          python -m pip install --upgrade pip
+
+      - name: Install build dependencies
+        run: python -m pip install -r build_requirements.txt
+
+      - name: Install additional OS dependencies - Ubuntu
+        run: os_dependencies/ubuntu.sh
+
+      - name: Build wheels
+        run: |
+          python build_wheels_from_file.py --requirements ${{ inputs.packages }}
+
+      - name: Upload artifacts of downloaded_wheels directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-download-directory-ubuntu-${{ matrix.python-version }}
+          path: ./downloaded_wheels
+
+
+  windows-latest:
+    name: windows x86_64
+    if: ${{ inputs.os_windows_latest }}
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version}}
+
+      - name: Get Python version
+        run: |
+          python --version
+          python -m pip install --upgrade pip
+
+      - name: Install build dependencies
+        run: python -m pip install -r build_requirements.txt
+
+      - name: Build wheels
+        run: |
+          python build_wheels_from_file.py --requirements ${{ inputs.packages }}
+
+      - name: Upload artifacts of downloaded_wheels directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-download-directory-windows-${{ matrix.python-version }}
+          path: ./downloaded_wheels
+
+
+  macos-latest:
+    name: macos x86_64
+    if: ${{ inputs.os_macos_latest }}
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version}}
+
+      - name: Get Python version
+        run: |
+          python --version
+          python -m pip install --upgrade pip
+
+      - name: Install build dependencies
+        run: python -m pip install -r build_requirements.txt
+
+      - name: Install additional OS dependencies - MacOS
+        run: os_dependencies/macos.sh
+
+      - name: Build wheels
+        run: |
+          python build_wheels_from_file.py --requirements ${{ inputs.packages }}
+
+      - name: Upload artifacts of downloaded_wheels directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-download-directory-macos-x86-${{ matrix.python-version }}
+          path: ./downloaded_wheels
+
+
+  macos-m1:
+    name: macos arm64
+    if: ${{ inputs.os_macos_arm64 }}
+    runs-on: macos-latest-xlarge       # MacOS M1 GitHub beta runner - paid $0.16
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python - MacOS M1
+        # Temporary solution until Python version for build will be >= 3.10 (GitHub action support)
+        run: |
+          brew install python@${{ matrix.python_version }}
+          # change python symlink called with default command 'python'
+          ln -s -f /opt/homebrew/bin/python${{ matrix.python_version }} /usr/local/bin/python
+
+      - name: Get Python version
+        run: |
+          python --version
+          python -m pip install --upgrade pip
+
+      - name: Install build dependencies
+        run: python -m pip install -r build_requirements.txt
+
+      - name: Install additional OS dependencies - MacOS
+        run: os_dependencies/macos.sh
+
+      - name: Build wheels
+        run: |
+          python build_wheels_from_file.py --requirements ${{ inputs.packages }}
+
+      - name: Upload artifacts of downloaded_wheels directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-download-directory-macos-arm64-${{ matrix.python-version }}
+          path: ./downloaded_wheels
+
+
+  linux-armv7:
+    name: linux aarch32 (armv7)
+    if: ${{ inputs.os_linux_armv7 }}
+    runs-on: linux-armv7-self-hosted
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version}}
+
+      - name: Get Python version
+        run: |
+          python --version
+          python -m pip install --upgrade pip
+
+      - name: Install build dependencies
+        run: python -m pip install -r build_requirements.txt
+
+      - name: Install additional OS dependencies - Linux ARM
+        run: os_dependencies/linux_arm.sh
+
+      - name: Build wheels
+        run: |
+          # Rust directory needs to be included for Linux ARM7
+          . $HOME/.cargo/env
+
+          python build_wheels_from_file.py --requirements ${{ inputs.packages }}
+
+      - name: Upload artifacts of downloaded_wheels directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-download-directory-linux-arm7-${{ matrix.python-version }}
+          path: ./downloaded_wheels
+
+
+  linux-arm64:
+    name: linux aarch64 (arm64)
+    if: ${{ inputs.os_linux_arm64 }}
+    runs-on: linux-arm64-self-hosted
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version}}
+
+      - name: Get Python version
+        run: |
+          python --version
+          python -m pip install --upgrade pip
+
+      - name: Install build dependencies
+        run: python -m pip install -r build_requirements.txt
+
+      - name: Install additional OS dependencies - Linux ARM
+        run: os_dependencies/linux_arm.sh
+
+      - name: Build wheels
+        run: |
+          python build_wheels_from_file.py --requirements ${{ inputs.packages }}
+
+      - name: Upload artifacts of downloaded_wheels directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-download-directory-linux-arm64-${{ matrix.python-version }}
+          path: ./downloaded_wheels
+
+
+  upload-python-wheels:
+    needs: [ubuntu-latest, windows-latest, macos-latest, macos-m1, linux-armv7, linux-arm64]
+    name: Upload Python wheels
+    uses: espressif/idf-python-wheels/.github/workflows/upload-python-wheels.yml@feat/python_version_specific_wheels
+    # TODO right branch to ref

--- a/.github/workflows/build-wheels-defined.yml
+++ b/.github/workflows/build-wheels-defined.yml
@@ -275,5 +275,4 @@ jobs:
   upload-python-wheels:
     needs: [ubuntu-latest, windows-latest, macos-latest, macos-m1, linux-armv7, linux-arm64]
     name: Upload Python wheels
-    uses: espressif/idf-python-wheels/.github/workflows/upload-python-wheels.yml@feat/python_version_specific_wheels
-    # TODO right branch to ref
+    uses: espressif/idf-python-wheels/.github/workflows/upload-python-wheels.yml@main

--- a/.github/workflows/build-wheels-defined.yml
+++ b/.github/workflows/build-wheels-defined.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -121,7 +121,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -159,7 +159,7 @@ jobs:
     runs-on: macos-latest-xlarge       # MacOS M1 GitHub beta runner - paid $0.16
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -199,7 +199,7 @@ jobs:
     runs-on: linux-armv7-self-hosted
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -240,7 +240,7 @@ jobs:
     runs-on: linux-arm64-self-hosted
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-arm64-self-hosted.yml
@@ -1,8 +1,8 @@
 name: linux-arm64-dispatch
 
 on:
-  schedule:
-     - cron: '0 0 * * 0,3'
+  # schedule:
+  #    - cron: '0 0 * * 0,3'
   workflow_dispatch:
     inputs:
       IDF_branch:

--- a/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
+++ b/.github/workflows/build-wheels-linux-armv7-self-hosted.yml
@@ -1,8 +1,8 @@
 name: armv7-dispatch
 
 on:
-  schedule:
-     - cron: '0 0 * * 0,3'
+  # schedule:
+  #    - cron: '0 0 * * 0,3'
   workflow_dispatch:
     inputs:
       IDF_branch:

--- a/.github/workflows/build-wheels-macos-M1-self-hosted.yml
+++ b/.github/workflows/build-wheels-macos-M1-self-hosted.yml
@@ -1,8 +1,8 @@
 name: macos-M1-dispatch
 
 on:
-  schedule:
-     - cron: '0 0 * * 0,3'
+  # schedule:
+  #    - cron: '0 0 * * 0,3'
   workflow_dispatch:
     inputs:
       IDF_branch:

--- a/.github/workflows/build-wheels-macos-dispatch.yml
+++ b/.github/workflows/build-wheels-macos-dispatch.yml
@@ -1,8 +1,8 @@
 name: macos-x64-dispatch
 
 on:
-  schedule:
-     - cron: '0 0 * * 0,3'
+  # schedule:
+  #    - cron: '0 0 * * 0,3'
   workflow_dispatch:
     inputs:
       IDF_branch:

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -2,7 +2,7 @@ name: platforms-dispatches
 
 on:
   schedule:
-   - cron: '0 0 * * 0,3'
+    - cron: '0 0 * * 0,3'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -5,7 +5,6 @@ on:
   #schedule:
   #  - cron: '0 0 * * 0,3'
   workflow_dispatch:
-  pull_request:
 
 env:
   MIN_IDF_MAJOR_VERSION: ${{ vars.MIN_IDF_MAJOR_VERSION }}

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -5,6 +5,7 @@ on:
   #schedule:
   #  - cron: '0 0 * * 0,3'
   workflow_dispatch:
+  pull_request:
 
 env:
   MIN_IDF_MAJOR_VERSION: ${{ vars.MIN_IDF_MAJOR_VERSION }}
@@ -127,8 +128,43 @@ jobs:
     # TODO right branch to ref
 
 
+  # upload-python-wheels:
+  #   needs: [build-wheels, build-python-version-dependent-wheels]
+  #   name: Upload Python wheels
+  #   uses: espressif/idf-python-wheels/.github/workflows/upload-python-wheels.yml@feat/python_version_specific_wheels
+  #   # TODO right branch to ref
   upload-python-wheels:
     needs: [build-wheels, build-python-version-dependent-wheels]
     name: Upload Python wheels
-    uses: espressif/idf-python-wheels/.github/workflows/upload-python-wheels.yml@feat/python_version_specific_wheels
-    # TODO right branch to ref
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      AWS_BUCKET: ${{ secrets.DL_BUCKET }}
+      PREFIX: 'pypi'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: python -m pip install -r build_requirements.txt
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          #name: wheels-download-directory
+          path: ./downloaded_wheels
+
+      - name: Upload release asset to S3 bucket
+        run: |
+          python upload_wheels.py $AWS_BUCKET
+          python create_index_pages.py $AWS_BUCKET
+      - name: Drop AWS cache
+        id: invalidate-index-cache
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"
+
+      - name: Remove temporary directory
+        run: rm -r downloaded_wheels

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -5,6 +5,7 @@ on:
   #schedule:
   #  - cron: '0 0 * * 0,3'
   workflow_dispatch:
+  pull_request:
 
 env:
   MIN_IDF_MAJOR_VERSION: ${{ vars.MIN_IDF_MAJOR_VERSION }}
@@ -12,7 +13,7 @@ env:
 
 jobs:
   build-wheels:
-    name: Build Python wheels for ${{ matrix.os }}
+    name: Build for ${{ matrix.os }} (Python ${{matrix.python-version}})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -81,69 +82,15 @@ jobs:
 
       - name: Install additional OS dependencies - Ubuntu
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
-          sudo apt install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-4.0 -y
-
-          # dbus-python needs build dependecies
-          sudo apt-get install cmake build-essential libdbus-1-dev libdbus-glib-1-dev -y
-
+        run: os_dependencies/ubuntu.sh
 
       - name: Install additional OS dependencies - MacOS
         if: matrix.os == 'macos-latest' || matrix.os == 'macos-latest-xlarge'
-        run: |
-          # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
-          brew install pygobject3 gtk4
+        run: os_dependencies/macos.sh
 
-          # MacOS M1 additional dependencies
-          if [ "${{ matrix.os }}" == "macos-latest-xlarge" ]; then
-            # Probably temporary fix for gdbgui==0.13.2.0 on MacOS M1 -> gevent==1.5.0 can't be build
-            # The newest version of gevent with M1 support is installed and forced to be used for gdbgui
-            # When requirement wheels are build gdbgui==0.13.2.0 is already built
-
-            arch -arm64 python -m pip install 'cython<3'
-            arch -arm64 python -m pip install 'cffi'
-            arch -arm64 python -m pip install 'gevent'
-            arch -arm64 python -m pip install 'gdbgui==0.13.2.0' --no-build-isolation
-          fi
-
-
-      - name: Install additional OS dependencies - Linux ARM7
-        if: matrix.os == 'linux-armv7-self-hosted'
-        run: |
-          apt-get update
-
-          # AWS
-          apt-get install -y -q --no-install-recommends awscli
-
-          # cryptography needs Rust
-          # clean the container Rust installation to be sure right interpreter is used
-          apt remove --auto-remove --purge rust-gdb rustc libstd-rust-dev libstd-rust-1.48
-          # install Rust dependencies
-          apt-get install -y build-essential libssl-dev libffi-dev python3-dev pkg-config gcc musl-dev
-          # install Rust
-          curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | bash -s -- -y
-          . $HOME/.cargo/env
-
-          # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
-          apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev -y
-
-          # dbus-python build dependecies
-          apt-get install libtiff5 libjpeg-dev libopenjp2-7 cmake libdbus-1-dev -y
-          apt-get install -y --no-install-recommends python3-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev -y
-          apt-get install -y --no-install-recommends dbus-tests -y
-
-
-      - name: Install additional OS dependencies - Linux ARM64
-        if: matrix.os == 'linux-arm64-self-hosted'
-        run: |
-          apt-get update
-
-          # AWS
-          apt-get install -y -q --no-install-recommends awscli
-
-          # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
-          apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev -y
+      - name: Install additional OS dependencies - Linux ARM
+        if: matrix.os == 'linux-armv7-self-hosted' || matrix.os == 'linux-arm64-self-hosted'
+        run: os_dependencies/linux_arm.sh
 
 
       - name: Build wheels for IDF
@@ -161,31 +108,28 @@ jobs:
         run: |
           python build_wheels.py
 
+      - name: Upload artifacts of downloaded_wheels directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-download-directory-${{ matrix.os}}-${{ matrix.python-version }}
+          path: ./downloaded_wheels
 
-      #- name: Build Python version dependendent wheels for IDF
-      #  uses: ./.github/workflows/build-wheels-python-dependent.yml
-
-
-      - name: Upload release asset to S3 bucket
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          AWS_BUCKET: ${{ secrets.DL_BUCKET }}
-          PREFIX: 'pypi'
-        shell: bash
-        run: |
-          python upload_wheels.py $AWS_BUCKET
-          python create_index_pages.py $AWS_BUCKET
+      - name: Upload artifacts of Python version dependent wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependent_requirements_${{ matrix.os}}
+          path: ./dependent_requirements.txt
 
 
-      - name: Drop AWS cache
-        id: invalidate-index-cache
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"
+  build-python-version-dependent-wheels:
+    needs: build-wheels
+    name: Build Python version dependendent wheels for IDF
+    uses: espressif/idf-python-wheels/.github/workflows/build-wheels-python-dependent.yml@feat/python_version_specific_wheels
+    # TODO right branch to ref
 
-      - name: Remove temporary directory
-        run: rm -r downloaded_wheels
+
+  upload-python-wheels:
+    needs: [build-wheels, build-python-version-dependent-wheels]
+    name: Upload Python wheels
+    uses: espressif/idf-python-wheels/.github/workflows/upload-python-wheels.yml@feat/python_version_specific_wheels
+    # TODO right branch to ref

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -1,11 +1,9 @@
 name: platforms-dispatches
 
 on:
-  # TODO schedule on final merge
-  #schedule:
-  #  - cron: '0 0 * * 0,3'
+  schedule:
+   - cron: '0 0 * * 0,3'
   workflow_dispatch:
-  pull_request:
 
 env:
   MIN_IDF_MAJOR_VERSION: ${{ vars.MIN_IDF_MAJOR_VERSION }}
@@ -124,15 +122,14 @@ jobs:
   build-python-version-dependent-wheels:
     needs: build-wheels
     name: Build Python version dependendent wheels for IDF
-    uses: espressif/idf-python-wheels/.github/workflows/build-wheels-python-dependent.yml@feat/python_version_specific_wheels
-    # TODO right branch to ref
+    uses: espressif/idf-python-wheels/.github/workflows/build-wheels-python-dependent.yml@main
 
 
+  #   # TODO in following PR: use the separate workflow bellow, right branch to ref
   # upload-python-wheels:
   #   needs: [build-wheels, build-python-version-dependent-wheels]
   #   name: Upload Python wheels
   #   uses: espressif/idf-python-wheels/.github/workflows/upload-python-wheels.yml@feat/python_version_specific_wheels
-  #   # TODO right branch to ref
   upload-python-wheels:
     needs: [build-wheels, build-python-version-dependent-wheels]
     name: Upload Python wheels
@@ -155,16 +152,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          #name: wheels-download-directory
           path: ./downloaded_wheels
 
       - name: Upload release asset to S3 bucket
         run: |
           python upload_wheels.py $AWS_BUCKET
           python create_index_pages.py $AWS_BUCKET
+
       - name: Drop AWS cache
         id: invalidate-index-cache
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"
-
-      - name: Remove temporary directory
-        run: rm -r downloaded_wheels

--- a/.github/workflows/build-wheels-python-dependent.yml
+++ b/.github/workflows/build-wheels-python-dependent.yml
@@ -1,11 +1,11 @@
-name: Build Python dependent wheels
+name: Build Python version dependent wheels
 
 on:
   workflow_call:
 
 jobs:
   triage:
-    name: Build Python wheels for ${{ matrix.os }}
+    name: ${{ matrix.os }} - ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -14,19 +14,42 @@ jobs:
           - windows-latest
           - ubuntu-latest
           - macos-latest
-          #- macos-latest-xlarge       # MacOS M1 GitHub beta runner - paid $0.16
+          - macos-latest-xlarge       # MacOS M1 GitHub beta runner - paid $0.16
           - linux-armv7-self-hosted
           - linux-arm64-self-hosted
+        python-version:
+          - '3.9'
+          - '3.10'
+          - '3.11'
         include:
           - os: linux-armv7-self-hosted
-            CONTAINER: [python:3.9-bullseye, python:3.10-bullseye, python:3.11-bullseye]
+            python-version: '3.9'
+            CONTAINER: 'python:3.9-bullseye'
+          - os: linux-armv7-self-hosted
+            python-version: '3.10'
+            CONTAINER: 'python:3.10-bullseye'
+          - os: linux-armv7-self-hosted
+            python-version: '3.11'
+            CONTAINER: 'python:3.11-bullseye'
+
           - os: linux-arm64-self-hosted
-            CONTAINER: [python:3.9-bullseye, python:3.10-bullseye, python:3.11-bullseye]
-        python-version: ['3.9', '3.10', '3.11']
+            python-version: '3.9'
+            CONTAINER: 'python:3.9-bullseye'
+          - os: linux-arm64-self-hosted
+            python-version: '3.10'
+            CONTAINER: 'python:3.10-bullseye'
+          - os: linux-arm64-self-hosted
+            python-version: '3.11'
+            CONTAINER: 'python:3.11-bullseye'
+
 
     # Use python container on ARM
     container: ${{ matrix.CONTAINER }}
+
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Python
         # GitHub action for MacOS M1 does not have Python <= 3.10
         # Skip setting python on ARM because of missing compatibility: https://github.com/actions/setup-python/issues/108
@@ -35,11 +58,62 @@ jobs:
         with:
             python-version: ${{ matrix.python-version }}
 
+      - name: Setup Python - MacOS M1
+        # Temporary solution until Python version for build will be >= 3.10 (GitHub action support)
+        if: matrix.os == 'macos-latest-xlarge'
+        run: |
+          brew install python@${{ matrix.python-version }}
+          # change python symlink called with default command 'python'
+          ln -s -f /opt/homebrew/bin/python${{ matrix.python-version }} /usr/local/bin/python
+
       - name: Get Python version
         run: |
             python --version
             python -m pip install --upgrade pip
 
+
+      - name: Install dependencies
+        run: python -m pip install -r build_requirements.txt
+
+      - name: Install additional OS dependencies - Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: os_dependencies/ubuntu.sh
+
+      - name: Install additional OS dependencies - MacOS
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-latest-xlarge'
+        run: os_dependencies/macos.sh
+
+
+      - name: Install additional OS dependencies - Linux ARM7
+        if: matrix.os == 'linux-armv7-self-hosted' || matrix.os == 'linux-arm64-self-hosted'
+        run: os_dependencies/linux_arm.sh
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dependent_requirements_${{ matrix.os}}
+          path: dependent_requirements_${{ matrix.os}}
+
+
       - name: Build Python dependent wheels for ${{ matrix.python-version }}
+        if: matrix.os != 'windows-latest'
         run: |
-          python build_wheels_from_file.py
+            # Rust directory needs to be included for Linux ARM7
+            if [ "${{ matrix.os }}" = "linux-armv7-self-hosted" ]; then
+              . $HOME/.cargo/env
+            fi
+
+            python build_wheels_from_file.py dependent_requirements_${{ matrix.os}}
+
+      - name: Build Python dependent wheels for ${{ matrix.python-version }} - Windows
+        if: matrix.os == 'windows-latest'
+        run: python build_wheels_from_file.py dependent_requirements_${{ matrix.os}}
+
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-download-directory-${{ matrix.os }}-${{ matrix.python-version }}
+          if-no-files-found: ignore
+          path: ./downloaded_wheels
+          retention-days: 1

--- a/.github/workflows/build-wheels-python-dependent.yml
+++ b/.github/workflows/build-wheels-python-dependent.yml
@@ -21,6 +21,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
         include:
           - os: linux-armv7-self-hosted
             python-version: '3.9'
@@ -31,6 +32,9 @@ jobs:
           - os: linux-armv7-self-hosted
             python-version: '3.11'
             CONTAINER: 'python:3.11-bullseye'
+          - os: linux-armv7-self-hosted
+            python-version: '3.12'
+            CONTAINER: 'python:3.12-bullseye'
 
           - os: linux-arm64-self-hosted
             python-version: '3.9'
@@ -41,6 +45,9 @@ jobs:
           - os: linux-arm64-self-hosted
             python-version: '3.11'
             CONTAINER: 'python:3.11-bullseye'
+          - os: linux-arm64-self-hosted
+            python-version: '3.12'
+            CONTAINER: 'python:3.12-bullseye'
 
 
     # Use python container on ARM
@@ -53,14 +60,14 @@ jobs:
       - name: Setup Python
         # GitHub action for MacOS M1 does not have Python <= 3.10
         # Skip setting python on ARM because of missing compatibility: https://github.com/actions/setup-python/issues/108
-        if: matrix.os != 'macos-latest-xlarge' && matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'linux-arm64-self-hosted'
+        if: (matrix.os != 'macos-latest-xlarge' && matrix.python-version != '3.12') && matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'linux-arm64-self-hosted'
         uses: actions/setup-python@v4
         with:
             python-version: ${{ matrix.python-version }}
 
       - name: Setup Python - MacOS M1
         # Temporary solution until Python version for build will be >= 3.10 (GitHub action support)
-        if: matrix.os == 'macos-latest-xlarge'
+        if: matrix.os == 'macos-latest-xlarge' && matrix.python-version != '3.12'
         run: |
           brew install python@${{ matrix.python-version }}
           # change python symlink called with default command 'python'

--- a/.github/workflows/build-wheels-ubuntu-dispatch.yml
+++ b/.github/workflows/build-wheels-ubuntu-dispatch.yml
@@ -1,8 +1,8 @@
 name: ubuntu-dispatch
 
 on:
-  schedule:
-     - cron: '0 0 * * 0,3'
+  # schedule:
+  #    - cron: '0 0 * * 0,3'
   workflow_dispatch:
     inputs:
       IDF_branch:

--- a/.github/workflows/build-wheels-windows-dispatch.yml
+++ b/.github/workflows/build-wheels-windows-dispatch.yml
@@ -1,8 +1,8 @@
 name: windows-dispatch
 
 on:
-  schedule:
-     - cron: '0 0 * * 0,3'
+  # schedule:
+  #    - cron: '0 0 * * 0,3'
   workflow_dispatch:
     inputs:
       IDF_branch:

--- a/.github/workflows/upload-python-wheels.yml
+++ b/.github/workflows/upload-python-wheels.yml
@@ -9,12 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      AWS_BUCKET: ${{ secrets.DL_BUCKET }}
-      PREFIX: 'pypi'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,7 +22,12 @@ jobs:
           path: ./downloaded_wheels
 
       - name: Upload release asset to S3 bucket
-        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_BUCKET: ${{ secrets.DL_BUCKET }}
+          PREFIX: 'pypi'
         run: |
           python upload_wheels.py $AWS_BUCKET
           python create_index_pages.py $AWS_BUCKET

--- a/.github/workflows/upload-python-wheels.yml
+++ b/.github/workflows/upload-python-wheels.yml
@@ -1,0 +1,42 @@
+name: upload-python-wheels
+
+on:
+  workflow_call:
+
+jobs:
+  triage:
+    name: Upload Python wheels
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      AWS_BUCKET: ${{ secrets.DL_BUCKET }}
+      PREFIX: 'pypi'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: python -m pip install -r build_requirements.txt
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./downloaded_wheels
+
+      - name: Upload release asset to S3 bucket
+        shell: bash
+        run: |
+          python upload_wheels.py $AWS_BUCKET
+          python create_index_pages.py $AWS_BUCKET
+
+      - name: Drop AWS cache
+        id: invalidate-index-cache
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"

--- a/.github/workflows/upload-python-wheels.yml
+++ b/.github/workflows/upload-python-wheels.yml
@@ -9,6 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      AWS_BUCKET: ${{ secrets.DL_BUCKET }}
+      PREFIX: 'pypi'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -22,20 +28,10 @@ jobs:
           path: ./downloaded_wheels
 
       - name: Upload release asset to S3 bucket
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          AWS_BUCKET: ${{ secrets.DL_BUCKET }}
-          PREFIX: 'pypi'
         run: |
           python upload_wheels.py $AWS_BUCKET
           python create_index_pages.py $AWS_BUCKET
 
       - name: Drop AWS cache
         id: invalidate-index-cache
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/pypi/*"

--- a/_helper_functions.py
+++ b/_helper_functions.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/_helper_functions.py
+++ b/_helper_functions.py
@@ -1,0 +1,14 @@
+#
+# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+from colorama import Fore
+from colorama import Style
+
+
+def print_color(text:str, color:str = Fore.BLUE):
+    """Print colored text specified by color argument based on colorama
+        - default color BLUE
+    """
+    print(f'{color}', f'{text}', Style.RESET_ALL)

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -15,9 +15,10 @@ from typing import Union
 import requests
 import yaml
 from colorama import Fore
-from colorama import Style
 from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
+
+from _helper_functions import print_color
 
 # GLOBAL VARIABLES
 # URL to fetch IDF branches from
@@ -38,13 +39,6 @@ MIN_IDF_MINOR_VERSION: int = int(os.environ.get('MIN_IDF_MINOR_VERSION', '0'))
 print(f'ENV variables: IDF v{MIN_IDF_MAJOR_VERSION}.{MIN_IDF_MINOR_VERSION}'
       f' -- grater or equal release and master branches will be considered'
       )
-
-
-def print_color(text:str, color:str = Fore.BLUE):
-    """Print colored text specified by color argument based on colorama
-        - default color BLUE
-    """
-    print(f'{color}', f'{text}', Style.RESET_ALL)
 
 
 def check_response(response: requests.Response, warning: str, exit_on_wrong: bool = False) -> bool:
@@ -349,7 +343,8 @@ def yaml_to_requirement(yaml_file:str, exclude: bool = False) -> set:
 
 def _merge_requirements(requirement:Requirement, req_to_exclude:Requirement) -> Requirement:
     if requirement.specifier and req_to_exclude.specifier:
-        new_specifier = requirement.specifier & req_to_exclude.specifier
+        # TODO  ++ gevent!=1.5.0,==1.5.0; python_version > "3.8"  !!
+        new_specifier = req_to_exclude.specifier
     elif requirement.specifier and not req_to_exclude.specifier:
         new_specifier = requirement.specifier
     elif not requirement.specifier and req_to_exclude.specifier:
@@ -470,7 +465,7 @@ def build_wheels(requirements: set, local_links:bool = True) -> dict:
     return {'failed': failed_wheels, 'succeeded': succeeded_wheels}
 
 
-def get_python_dependent_wheels(wheel_dir:str, requirements:set, store:bool = True) -> set:
+def get_python_dependent_wheels(wheel_dir:str, requirements:set) -> set:
     """Get Python dependent requirements from downloaded wheel directory"""
     dependent_wheels_set = set()
     dependent_requirements_set = set()
@@ -494,21 +489,17 @@ def get_python_dependent_wheels(wheel_dir:str, requirements:set, store:bool = Tr
         for requirement in requirements:
             if requirement.marker:
                 if 'python_version' in str(requirement.marker):
-                    #python_version_requirements.add(requirement)
-                    #dependent_requirements_set.add(requirement)
+                    # add python version specific requirements from all branches
+                    ##python_version_requirements.add(requirement)
+                    dependent_requirements_set.add(requirement)
                     pass
 
             if name.lower() == requirement.name.lower():
                 # add requirements with markers
                 dependent_requirements_set.add(requirement)
             else:
-                # add downloaded requirement (all dependencies)
-                dependent_requirements_set.add(f'{name}=={version}')
-
-    if store:
-        with open('dependent_requirements.txt', 'w') as f:
-            for wheel in dependent_requirements_set:
-                f.write(f'{str(wheel)}\n')
+                # add downloaded and already built requirements (all dependencies)
+                dependent_requirements_set.add(Requirement(f'{name}=={version}'))
 
     return dependent_requirements_set
 
@@ -552,13 +543,14 @@ def main() -> int:
     if failed_wheels != 0:
         raise SystemExit('One or more wheels failed to build')
 
-    print_color('---------- PYTHON VERSION DEPENDENT REQUIREMENTS ----------')
+    print_color('---------- PYTHON VERSION DEPENDENT ----------')
     dependent_wheels = get_python_dependent_wheels(f'{os.path.curdir}{(os.sep)}downloaded_wheels',
                                                    after_exclude_requirements)
+    after_exclude_dependent_wheels = exclude_from_requirements(dependent_wheels, exclude_list)
 
-    for req in dependent_wheels:
-        print(req)
-    print_color('---------- END OF PYTHON VERSION DEPENDENT REQUIREMENTS ----------')
+    with open('dependent_requirements.txt', 'w') as f:
+        for wheel in after_exclude_dependent_wheels:
+            f.write(f'{str(wheel)}\n')
 
     return 0
 

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/build_wheels.py
+++ b/build_wheels.py
@@ -343,7 +343,6 @@ def yaml_to_requirement(yaml_file:str, exclude: bool = False) -> set:
 
 def _merge_requirements(requirement:Requirement, req_to_exclude:Requirement) -> Requirement:
     if requirement.specifier and req_to_exclude.specifier:
-        # TODO  ++ gevent!=1.5.0,==1.5.0; python_version > "3.8"  !!
         new_specifier = req_to_exclude.specifier
     elif requirement.specifier and not req_to_exclude.specifier:
         new_specifier = requirement.specifier
@@ -469,7 +468,6 @@ def get_python_dependent_wheels(wheel_dir:str, requirements:set) -> set:
     """Get Python dependent requirements from downloaded wheel directory"""
     dependent_wheels_set = set()
     dependent_requirements_set = set()
-    #python_version_requirements = set()
 
     file_names = os.listdir(wheel_dir)
 
@@ -490,9 +488,7 @@ def get_python_dependent_wheels(wheel_dir:str, requirements:set) -> set:
             if requirement.marker:
                 if 'python_version' in str(requirement.marker):
                     # add python version specific requirements from all branches
-                    ##python_version_requirements.add(requirement)
                     dependent_requirements_set.add(requirement)
-                    pass
 
             if name.lower() == requirement.name.lower():
                 # add requirements with markers

--- a/build_wheels_from_file.py
+++ b/build_wheels_from_file.py
@@ -13,42 +13,75 @@ from colorama import Fore
 from _helper_functions import print_color
 
 parser = argparse.ArgumentParser(description='Process build arguments.')
-parser.add_argument('requirements_path', metavar='Path', type=str, nargs='+',
+parser.add_argument('requirements_path', metavar='Path', type=str, nargs='?', default='',
                     help='path to Python version dependent requirements txt')
+
+parser.add_argument('-r', '--requirements', metavar='Requirement/s', type=str, nargs='*',
+                    help='requirement/s to be build wheel/s for')
 
 args = parser.parse_args()
 
-requirements_dir = args.requirements_path[0]
+
+requirements_dir = args.requirements_path
+in_requirements = args.requirements
 
 failed_wheels = 0
 succeeded_wheels = 0
 
-try:
-    with open(f'{requirements_dir}{os.sep}dependent_requirements.txt', 'r') as f:
-        requirements = f.readlines()
-except Exception as e:
-    raise SystemExit(f'Python version dependent requirements directory or file not found ({e})')
+# Build wheels for requirements in file
+if requirements_dir:
+    try:
+        with open(f'{requirements_dir}{os.sep}dependent_requirements.txt', 'r') as f:
+            requirements = f.readlines()
+    except Exception as e:
+        raise SystemExit(f'Python version dependent requirements directory or file not found ({e})')
 
-for requirement in requirements:
-    out = subprocess.run(
-            [f'{sys.executable}', '-m', 'pip', 'wheel', f'{requirement}',
-             '--find-links', 'downloaded_wheels', '--wheel-dir', 'downloaded_wheels'],
-             stdout=subprocess.PIPE, stderr=subprocess.PIPE
-             )
+    for requirement in requirements:
+        out = subprocess.run(
+                [f'{sys.executable}', '-m', 'pip', 'wheel', f'{requirement}',
+                 '--find-links', 'downloaded_wheels', '--wheel-dir', 'downloaded_wheels'],
+                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                 )
 
-    print(out.stdout.decode('utf-8'))
-    if out.stderr:
-        print_color(out.stderr.decode('utf-8'), Fore.RED)
+        print(out.stdout.decode('utf-8'))
+        if out.stderr:
+            print_color(out.stderr.decode('utf-8'), Fore.RED)
 
-    if out.returncode != 0:
-        failed_wheels += 1
-    else:
-        succeeded_wheels += 1
+        if out.returncode != 0:
+            failed_wheels += 1
+        else:
+            succeeded_wheels += 1
 
 
-print_color('---------- STATISTICS ----------')
-print_color(f'Succeeded {succeeded_wheels} wheels', Fore.GREEN)
-print_color(f'Failed {failed_wheels} wheels', Fore.RED)
+    print_color('---------- STATISTICS ----------')
+    print_color(f'Succeeded {succeeded_wheels} wheels', Fore.GREEN)
+    print_color(f'Failed {failed_wheels} wheels', Fore.RED)
 
-if failed_wheels != 0:
-    raise SystemExit('One or more wheels failed to build')
+    if failed_wheels != 0:
+        raise SystemExit('One or more wheels failed to build')
+
+# Build wheels from passed requirements
+else:
+    for requirement in in_requirements:
+        out = subprocess.run(
+                [f'{sys.executable}', '-m', 'pip', 'wheel', f'{requirement}',
+                 '--find-links', 'downloaded_wheels', '--wheel-dir', 'downloaded_wheels'],
+                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                 )
+
+        print(out.stdout.decode('utf-8'))
+        if out.stderr:
+            print_color(out.stderr.decode('utf-8'), Fore.RED)
+
+        if out.returncode != 0:
+            failed_wheels += 1
+        else:
+            succeeded_wheels += 1
+
+
+    print_color('---------- STATISTICS ----------')
+    print_color(f'Succeeded {succeeded_wheels} wheels', Fore.GREEN)
+    print_color(f'Failed {failed_wheels} wheels', Fore.RED)
+
+    if failed_wheels != 0:
+        raise SystemExit('One or more wheels failed to build')

--- a/build_wheels_from_file.py
+++ b/build_wheels_from_file.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -16,8 +16,8 @@ parser = argparse.ArgumentParser(description='Process build arguments.')
 parser.add_argument('requirements_path', metavar='Path', type=str, nargs='?', default='',
                     help='path to Python version dependent requirements txt')
 
-parser.add_argument('-r', '--requirements', metavar='Requirement/s', type=str, nargs='*',
-                    help='requirement/s to be build wheel/s for')
+parser.add_argument('-r', '--requirements', metavar='Requirement(s)', type=str, nargs='*',
+                    help='requirement(s) to be build wheel(s) for')
 
 args = parser.parse_args()
 
@@ -33,7 +33,7 @@ if requirements_dir:
     try:
         with open(f'{requirements_dir}{os.sep}dependent_requirements.txt', 'r') as f:
             requirements = f.readlines()
-    except Exception as e:
+    except FileNotFoundError as e:
         raise SystemExit(f'Python version dependent requirements directory or file not found ({e})')
 
     for requirement in requirements:

--- a/build_wheels_from_file.py
+++ b/build_wheels_from_file.py
@@ -3,14 +3,31 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+import argparse
+import os
 import subprocess
 import sys
+
+from colorama import Fore
+
+from _helper_functions import print_color
+
+parser = argparse.ArgumentParser(description='Process build arguments.')
+parser.add_argument('requirements_path', metavar='Path', type=str, nargs='+',
+                    help='path to Python version dependent requirements txt')
+
+args = parser.parse_args()
+
+requirements_dir = args.requirements_path[0]
 
 failed_wheels = 0
 succeeded_wheels = 0
 
-with open('dependent_requirements.txt', 'r') as f:
-    requirements = f.readlines()
+try:
+    with open(f'{requirements_dir}{os.sep}dependent_requirements.txt', 'r') as f:
+        requirements = f.readlines()
+except Exception as e:
+    raise SystemExit(f'Python version dependent requirements directory or file not found ({e})')
 
 for requirement in requirements:
     out = subprocess.run(
@@ -21,7 +38,7 @@ for requirement in requirements:
 
     print(out.stdout.decode('utf-8'))
     if out.stderr:
-        print(out.stderr.decode('utf-8'))
+        print_color(out.stderr.decode('utf-8'), Fore.RED)
 
     if out.returncode != 0:
         failed_wheels += 1
@@ -29,6 +46,9 @@ for requirement in requirements:
         succeeded_wheels += 1
 
 
-print('---------- STATISTICS ----------')
-print(f'Succeeded {succeeded_wheels} wheels')
-print(f'Failed {failed_wheels} wheels')
+print_color('---------- STATISTICS ----------')
+print_color(f'Succeeded {succeeded_wheels} wheels', Fore.GREEN)
+print_color(f'Failed {failed_wheels} wheels', Fore.RED)
+
+if failed_wheels != 0:
+    raise SystemExit('One or more wheels failed to build')

--- a/exclude_list.yaml
+++ b/exclude_list.yaml
@@ -10,3 +10,14 @@
 # dbus-python can not be build on Windows
 - package_name: 'dbus-python'
   platform: ['win32']
+  python: '==3.11" and sys_platform == "darwin' # temporary workaround for macos Python 3.11 until dbus-python support drop
+  # More entries of the same requirement in this list are not merged which may leads into unwanted behavior
+
+# gevent==1.5.0 can not be build with Python > 3.8
+- package_name: 'gevent'
+  version: '==1.5.0'
+  python: '>3.8'
+
+# gdbgui==0.13.2.0 leads to installation of gevent 1.5.0 which can not be build
+- package_name: 'gdbgui'
+  version: '==0.13.2.0'

--- a/exclude_list.yaml
+++ b/exclude_list.yaml
@@ -1,5 +1,5 @@
 # List of Python packages to exclude from automatically assembled requirements
-#"From assembled <main requirements> exclude <package_name> with <version> on <platform>".
+#"From assembled <main requirements> exclude <package_name> with <version> on <platform> for <python> version".
 
 # exclude_list template
 #- package_name: '<name_of_package>'

--- a/exclude_list.yaml
+++ b/exclude_list.yaml
@@ -10,7 +10,7 @@
 # dbus-python can not be build on Windows
 - package_name: 'dbus-python'
   platform: ['win32']
-  python: '==3.11" and sys_platform == "darwin' # temporary workaround for macos Python 3.11 until dbus-python support drop
+  python: '>3.11" and sys_platform == "darwin' # temporary workaround for macos Python 3.11 until dbus-python support drop
   # More entries of the same requirement in this list are not merged which may leads into unwanted behavior
 
 # gevent==1.5.0 can not be build with Python > 3.8

--- a/include_list.yaml
+++ b/include_list.yaml
@@ -6,3 +6,7 @@
 #    version: '<package_version_with_operator>' / ['<package_version_with_operator>', '<package_version_with_operator>']     # optional
 #    platform: '<platform>' / ['<platform>', '<platform>', '<platform>']                                                     # optional
 #    python: '<python_version_with_operator>' / ['<python_version>', '<python_version>', '<python_version>']                 # optional
+
+- package_name: 'gdbgui'
+  version: '>=0.15.2.0'
+  platform: ['linux', 'darwin']

--- a/include_list.yaml
+++ b/include_list.yaml
@@ -1,5 +1,5 @@
 # List of Python packages to additionally include to the automatically assembled requirements
-#"For assembled <main requirements> additionally include <package_name> with <version> on <platform>".
+#"For assembled <main requirements> additionally include <package_name> with <version> on <platform> for <python> version".
 
 # include_list template
 #- package_name: '<name_of_package>'

--- a/os_dependencies/linux_arm.sh
+++ b/os_dependencies/linux_arm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+arch=$(uname -m)
+
+apt-get update
+
+# AWS
+apt-get install -y -q --no-install-recommends awscli
+
+# PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
+apt-get install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev -y
+
+
+#Only ARMv7
+if [ "$arch" == "armv7l" ]; then
+    # cryptography needs Rust
+    # clean the container Rust installation to be sure right interpreter is used
+    apt remove --auto-remove --purge rust-gdb rustc libstd-rust-dev libstd-rust-1.48
+    # install Rust dependencies
+    apt-get install -y build-essential libssl-dev libffi-dev python3-dev pkg-config gcc musl-dev
+    # install Rust
+    curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | bash -s -- -y
+    . $HOME/.cargo/env
+
+    # dbus-python build dependecies
+    apt-get install libtiff5 libjpeg-dev libopenjp2-7 cmake libdbus-1-dev -y
+    apt-get install -y --no-install-recommends python3-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev -y
+    apt-get install -y --no-install-recommends dbus-tests -y
+fi

--- a/os_dependencies/macos.sh
+++ b/os_dependencies/macos.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+arch=$(uname -m)
+
+# PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
+brew install pygobject3 gtk4
+
+# Only MacOS M1 additional dependencies
+if [ "$arch" == "arm64" ]; then
+    echo "M1 additional dependencies"
+fi

--- a/os_dependencies/ubuntu.sh
+++ b/os_dependencies/ubuntu.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
+sudo apt install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-4.0 -y
+
+# dbus-python needs build dependecies
+sudo apt-get install cmake build-essential libdbus-1-dev libdbus-glib-1-dev -y

--- a/test_build_wheels.py
+++ b/test_build_wheels.py
@@ -1,7 +1,7 @@
 # ruff: noqa: E501
 # line too long skip in ruff for whole file (formatting would be worst than long lines)
 #
-# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/upload_wheels.py
+++ b/upload_wheels.py
@@ -23,16 +23,19 @@ WHEELS_DIR = f'{os.path.curdir}{(os.sep)}downloaded_wheels'
 if not os.path.exists(WHEELS_DIR):
     raise SystemExit(f'Error: The wheels directory {WHEELS_DIR} not found.')
 
-wheel_files = os.listdir(WHEELS_DIR)
+wheels_subdirs = os.listdir(WHEELS_DIR)
 
-for wheel in wheel_files:
-    pattern = re.compile(r'(\w*)-(\d+)')
-    match = pattern.search(wheel)
-    if match:
-        wheel_name = match.group(1)
+for subdir in wheels_subdirs:
+    wheel_files = os.listdir(f'{WHEELS_DIR}{os.sep}{subdir}')
 
-    wheel_name = wheel_name.lower()
-    wheel_name = wheel_name.replace('_', '-')
+    for wheel in wheel_files:
+        pattern = re.compile(r'(\w*)-(\d+)')
+        match = pattern.search(wheel)
+        if match:
+            wheel_name = match.group(1)
 
-    BUCKET.upload_file(f'{WHEELS_DIR}{os.sep}{wheel}', f'pypi/{wheel_name}/{wheel}')
-    print(f'Uploaded {wheel}')
+        wheel_name = wheel_name.lower()
+        wheel_name = wheel_name.replace('_', '-')
+
+        BUCKET.upload_file(f'{WHEELS_DIR}{os.sep}{subdir}{os.sep}{wheel}', f'pypi/{wheel_name}/{wheel}')
+        print(f'Uploaded {wheel}')

--- a/upload_wheels.py
+++ b/upload_wheels.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2023-2024 Espressif Systems (Shanghai) CO LTD
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
- Added wheels build for Python version specific wheels - [workflow run](https://github.com/espressif/idf-python-wheels/actions/runs/7408391172?pr=23)
This means all supported Python versions will be covered (3.8, 3.9, 3.10, 3.11)
- Refactored `build-wheels-ad-hoc` into `build-wheels-defined` to be compatible with new approach (workflow that takes given requirement/s and for chosen platform/s builds the wheel/s and uploads to AWS)
- Added schedule for new wheels build and disabled the old ones
--------
This PR has to be marged to allow test `build-wheels-defined` workflow and to enable usage of reusable workflow `upload-python-wheels.yml`