### PR TITLE
ci(danger-action): replace danger action with shared-github-danger (IDFGH-11843)

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,4 +1,4 @@
-name: DangerJS GitHub Check
+name: DangerJS Pull Request linter
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out PR head
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: DangerJS pull request linter
-      uses: espressif/github-actions/danger_pr_review@master
+      uses: espressif/shared-github-dangerjs@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces old version of Danger GitHub by our new tool from shared repo. 

Old version will be removed in 03/2024.

<img src="https://github.com/espressif/idf-python-wheels/assets/33937168/878e1737-91bc-4f2d-b3c6-5f85785dcfa0" width=500px> 

## Related
- spotted in: https://github.com/espressif/idf-python-wheels/pull/23#
