### PR TITLE
fix: Platform depended wheels Python versions

### DIFF
--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -124,7 +124,6 @@ jobs:
     name: Build Python version dependendent wheels for IDF
     uses: espressif/idf-python-wheels/.github/workflows/build-wheels-python-dependent.yml@main
 
-
   upload-python-wheels:
     needs: [build-wheels, build-python-version-dependent-wheels]
     name: Upload Python wheels

--- a/.github/workflows/build-wheels-python-dependent.yml
+++ b/.github/workflows/build-wheels-python-dependent.yml
@@ -60,16 +60,26 @@ jobs:
       - name: Setup Python
         # GitHub action for MacOS M1 does not have Python <= 3.10
         # Skip setting python on ARM because of missing compatibility: https://github.com/actions/setup-python/issues/108
-        if: (matrix.os != 'macos-latest-xlarge' && matrix.python-version != '3.12') && matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'linux-arm64-self-hosted'
+        if: matrix.os != 'macos-latest-xlarge' && matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'linux-arm64-self-hosted'
         uses: actions/setup-python@v5
         with:
             python-version: ${{ matrix.python-version }}
 
       - name: Setup Python - MacOS M1
         # Temporary solution until Python version for build will be >= 3.10 (GitHub action support)
-        if: matrix.os == 'macos-latest-xlarge' && matrix.python-version != '3.12'
+        if: matrix.os == 'macos-latest-xlarge'
         run: |
           brew install python@${{ matrix.python-version }}
+
+          # correcting pip installation for later usage such as Python module
+          # to be used from global scope since no venv is used
+          # because of the "managed environment error"
+          if [ "${{ matrix.python-version }}" == "3.12" ]; then
+            mkdir -p ~/.config/pip
+            echo "[global]" >> ~/.config/pip/pip.conf
+            echo "break-system-packages = true" >> ~/.config/pip/pip.conf
+          fi
+
           # change python symlink called with default command 'python'
           ln -s -f /opt/homebrew/bin/python${{ matrix.python-version }} /usr/local/bin/python
 


### PR DESCRIPTION
The Python version for the wheels build was sometimes incorrect because of the condition.

- fixed the condition
- [fixed `MacOS M1` issue](https://github.com/espressif/idf-python-wheels/pull/30#issuecomment-2158031890)