### PR TITLE
fix(mac_dispatch): Fixed runner tags to satisfy the need for right architectures

### DIFF
--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
+        os: # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
           - windows-latest
           - ubuntu-latest
-          - macos-latest
-          - macos-latest-xlarge       # MacOS M1 GitHub beta runner - paid $0.16
+          - macos-13      # MacOS x86_64
+          - macos-latest  # MacOS arm64 (M1)
           - linux-armv7-self-hosted
           - linux-arm64-self-hosted
         include:
@@ -51,21 +51,11 @@ jobs:
 
 
       - name: Setup Python
-        # GitHub action for MacOS M1 does not have Python <= 3.10
         # Skip setting python on ARM because of missing compatibility: https://github.com/actions/setup-python/issues/108
-        if: matrix.os != 'macos-latest-xlarge' && matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'linux-arm64-self-hosted'
+        if: matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'linux-arm64-self-hosted'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-
-      - name: Setup Python - MacOS M1
-        # Temporary solution until Python version for build will be >= 3.10 (GitHub action support)
-        if: matrix.os == 'macos-latest-xlarge'
-        run: |
-          brew install python@3.8
-          # change python symlink called with default command 'python'
-          ln -s -f /opt/homebrew/bin/python3.8 /usr/local/bin/python
 
 
       - name: Get Python version
@@ -83,7 +73,7 @@ jobs:
         run: os_dependencies/ubuntu.sh
 
       - name: Install additional OS dependencies - MacOS
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-latest-xlarge'
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
         run: os_dependencies/macos.sh
 
       - name: Install additional OS dependencies - Linux ARM

--- a/.github/workflows/build-wheels-python-dependent.yml
+++ b/.github/workflows/build-wheels-python-dependent.yml
@@ -13,8 +13,8 @@ jobs:
         os:
           - windows-latest
           - ubuntu-latest
-          - macos-latest
-          - macos-latest-xlarge       # MacOS M1 GitHub beta runner - paid $0.16
+          - macos-13      # MacOS x86_64
+          - macos-latest  # MacOS arm64 (M1)
           - linux-armv7-self-hosted
           - linux-arm64-self-hosted
         python-version:
@@ -58,30 +58,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        # GitHub action for MacOS M1 does not have Python <= 3.10
         # Skip setting python on ARM because of missing compatibility: https://github.com/actions/setup-python/issues/108
-        if: matrix.os != 'macos-latest-xlarge' && matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'linux-arm64-self-hosted'
+        if: matrix.os != 'linux-armv7-self-hosted' && matrix.os != 'linux-arm64-self-hosted'
         uses: actions/setup-python@v5
         with:
             python-version: ${{ matrix.python-version }}
 
-      - name: Setup Python - MacOS M1
-        # Temporary solution until Python version for build will be >= 3.10 (GitHub action support)
-        if: matrix.os == 'macos-latest-xlarge'
-        run: |
-          brew install python@${{ matrix.python-version }}
-
-          # correcting pip installation for later usage such as Python module
-          # to be used from global scope since no venv is used
-          # because of the "managed environment error"
-          if [ "${{ matrix.python-version }}" == "3.12" ]; then
-            mkdir -p ~/.config/pip
-            echo "[global]" >> ~/.config/pip/pip.conf
-            echo "break-system-packages = true" >> ~/.config/pip/pip.conf
-          fi
-
-          # change python symlink called with default command 'python'
-          ln -s -f /opt/homebrew/bin/python${{ matrix.python-version }} /usr/local/bin/python
 
       - name: Get Python version
         run: |
@@ -97,7 +79,7 @@ jobs:
         run: os_dependencies/ubuntu.sh
 
       - name: Install additional OS dependencies - MacOS
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-latest-xlarge'
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
         run: os_dependencies/macos.sh
 
 

--- a/os_dependencies/macos.sh
+++ b/os_dependencies/macos.sh
@@ -5,6 +5,12 @@ arch=$(uname -m)
 # PyGObject needs build dependecies https://pygobject.readthedocs.io/en/latest/getting_started.html
 brew install pygobject3 gtk4
 
+
+# Only MacOS x86_64 additional dependencies
+if [ "$arch" == "x86_64" ]; then
+    echo "x86_64 additional dependencies"
+fi
+
 # Only MacOS M1 additional dependencies
 if [ "$arch" == "arm64" ]; then
     echo "M1 additional dependencies"


### PR DESCRIPTION
- changed runner tags to cover `arm64` and `x86_64` architectures
- removed temporary solution for `Mac` with `arm64` architecture

Tested on [successful build](https://github.com/espressif/idf-python-wheels/actions/runs/9578703137/job/26412065336) - in the `macos-13` or `macos-latest` workflow under the `OS info` job, there are visible the correct architectures `x86_64` or` arm64` which are the wheels being built for.