### PR TITLE
Feat/authenticated api calls

### DIFF
--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -8,6 +8,7 @@ on:
 env:
   MIN_IDF_MAJOR_VERSION: ${{ vars.MIN_IDF_MAJOR_VERSION }}
   MIN_IDF_MINOR_VERSION: ${{ vars.MIN_IDF_MINOR_VERSION }}
+  GH_TOKEN : ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build-wheels:

--- a/exclude_list.yaml
+++ b/exclude_list.yaml
@@ -24,3 +24,7 @@
 # gdbgui==0.13.2.0 leads to installation of gevent 1.5.0 which can not be build
 - package_name: 'gdbgui'
   version: '==0.13.2.0'
+
+# cffi==1.17.0 does not exist yet it is required by some wheel (7/11/2024)
+- package_name: 'cffi'
+  version: '==1.17.0'


### PR DESCRIPTION
- Added authenticated GH API calls to extend API request limit to avoid failed builds (e.g. this[ pipeline](https://github.com/espressif/idf-python-wheels/actions/runs/9865991398/job/27243969122))
- Added a "pretty" (human-readable) `Simple index` page for Espressif's PyPI - ["pretty" Espressif's PyPI preview](https://dl.espressif.com/pypi/pretty/)
- Added into `exclude` list `cffi==1.17.0` some wheel required this even if this version does not exist (7/11/2024)

Unauthenticated API requests are limited to about 60 per hour and authenticated API calls are limited to about 5000 per hour, so this should solve the API rate limit issue.

[Successful pipeline preview](https://github.com/espressif/idf-python-wheels/actions/runs/9902890661)