### PR TITLE
Revert "Delete .github/workflows/build-cmake-linux-armv7.yml (IDFGH-14061)" (IDFGH-14478)

### DIFF
--- a/.github/workflows/build-cmake-linux-armv7.yml
+++ b/.github/workflows/build-cmake-linux-armv7.yml
@@ -1,0 +1,58 @@
+name: armv7-cmake-dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      cmake_version:
+        description: >
+          Cmake version to build and upload
+          For example 3.23.1
+        type: string
+        required: true
+
+jobs:
+  build-cmake:
+    name: Build cmake for linux-armv7
+    runs-on:
+      - self-hosted
+      - ARM
+    container:
+      image: ghcr.io/espressif/github-esp-dockerfiles/pyenv_rust_powershell:v2
+      options: --privileged
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Download and unpack cmake
+        shell: bash
+        run: |
+          wget "https://github.com/Kitware/CMake/releases/download/v${{ inputs.cmake_version }}/cmake-${{ inputs.cmake_version }}.tar.gz"
+          tar -xf "cmake-${{ inputs.cmake_version }}.tar.gz"
+      - name: Build cmake
+        shell: bash
+        run: |
+          cd "cmake-${{ inputs.cmake_version }}"
+          mkdir cmake-build
+          cd cmake-build
+          ../bootstrap && make && make install
+      - name: Create packages
+        shell: bash
+        working-directory: 'cmake-${{ inputs.cmake_version }}/cmake-build'
+        run: cpack -G TGZ && cpack -G STGZ
+      - name: Upload cmake to s3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_BUCKET: ${{ secrets.DL_BUCKET }}
+          PREFIX: 'dl/cmake'
+        shell: bash
+        working-directory: 'cmake-${{ inputs.cmake_version }}/cmake-build'
+        run: |
+          aws s3 cp --acl=public-read --no-progress "cmake-${{ inputs.cmake_version }}-Linux-armv7l.tar.gz" "s3://$AWS_BUCKET/dl/cmake/cmake-${{ inputs.cmake_version }}-Linux-armv7l.tar.gz"
+      - name: Drop AWS cache
+        id: invalidate-index-cache
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CACHE_INVALIDATION }} --paths "/dl/cmake/*"


### PR DESCRIPTION
Reverts espressif/idf-python-wheels#36

The alternative solution turned out to be more labor-intensive and wasn't merged.

I propose reverting this change, we do not need to build it too often, so manual dispatch should be ok. 