### PR TITLE
Don't build esptool wheels

### DIFF
--- a/exclude_list.yaml
+++ b/exclude_list.yaml
@@ -49,3 +49,6 @@
 - package_name: 'ruamel.yaml.clib'
   version: '==0.2.8'
   python: '==3.13'
+
+# Esptool wheels many times are faulty. Mostly because it installs "esptool.py" which collides with the package name.
+- package_name: 'esptool'


### PR DESCRIPTION
esptool.py version installed from the 4.9.1 wheel produces the following error:
ModuleNotFoundError: No module named 'esptool.__init__'; 'esptool' is not a package

The issue is not present if the package is installed from tar.gz.

pytest-embedded is also broken because of this issue.

See also https://github.com/espressif/esptool/issues/1107.