### PR TITLE
Fixed ARMv7 segmentation fault

### DIFF
--- a/.github/workflows/build-wheels-defined.yml
+++ b/.github/workflows/build-wheels-defined.yml
@@ -66,10 +66,10 @@ jobs:
         python-version: ${{ fromJson(needs.get-supported-versions.outputs.supported_python) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version}}
 
@@ -89,7 +89,7 @@ jobs:
           python build_wheels_from_file.py --requirements ${{ inputs.packages }}
 
       - name: Upload artifacts of downloaded_wheels directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-download-directory-linux-x86_64-${{ matrix.python-version }}
           path: ./downloaded_wheels
@@ -106,10 +106,10 @@ jobs:
         python-version: ${{ fromJson(needs.get-supported-versions.outputs.supported_python) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version}}
 
@@ -129,7 +129,7 @@ jobs:
           python build_wheels_from_file.py --requirements ${{ inputs.packages }}
 
       - name: Upload artifacts of downloaded_wheels directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-download-directory-windows-x86_64-${{ matrix.python-version }}
           path: ./downloaded_wheels
@@ -146,10 +146,10 @@ jobs:
         python-version: ${{ fromJson(needs.get-supported-versions.outputs.supported_python) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version}}
 
@@ -171,7 +171,7 @@ jobs:
           python build_wheels_from_file.py --requirements ${{ inputs.packages }}
 
       - name: Upload artifacts of downloaded_wheels directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-download-directory-macos-x86_64-${{ matrix.python-version }}
           path: ./downloaded_wheels
@@ -188,7 +188,7 @@ jobs:
         python-version: ${{ fromJson(needs.get-supported-versions.outputs.supported_python) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
         # Temporary solution until Python version for build will be >= 3.10 (GitHub action support)
@@ -223,7 +223,7 @@ jobs:
           python build_wheels_from_file.py --requirements ${{ inputs.packages }}
 
       - name: Upload artifacts of downloaded_wheels directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-download-directory-macos-arm64-${{ matrix.python-version }}
           path: ./downloaded_wheels
@@ -240,12 +240,12 @@ jobs:
         python-version: ${{ fromJson(needs.get-supported-versions.outputs.supported_python) }}
     steps:
       - name: Set up QEMU for ARMv7
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm/v7
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build wheels - ARMv7 (in Docker)
         run: |
@@ -271,7 +271,7 @@ jobs:
             "
 
       - name: Upload artifacts of downloaded_wheels directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-download-directory-linux-armv7-${{ matrix.python-version }}
           path: ./downloaded_wheels
@@ -289,7 +289,7 @@ jobs:
     container: python:${{ matrix.python-version }}-bookworm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get Python version
         run: |
@@ -307,7 +307,7 @@ jobs:
           python build_wheels_from_file.py --requirements ${{ inputs.packages }}
 
       - name: Upload artifacts of downloaded_wheels directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-download-directory-linux-arm64-${{ matrix.python-version }}
           path: ./downloaded_wheels
@@ -327,12 +327,12 @@ jobs:
           - python-version: '3.14'
     steps:
       - name: Set up QEMU for ARMv7
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm/v7
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build wheels - ARMv7 Legacy (in Docker)
         # Build on Bullseye (glibc 2.31) for compatibility with older systems
@@ -359,7 +359,7 @@ jobs:
             "
 
       - name: Upload artifacts of downloaded_wheels directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-download-directory-linux-armv7legacy-${{ matrix.python-version }}
           path: ./downloaded_wheels
@@ -392,7 +392,7 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get latest Python version
         id: python-version
@@ -402,7 +402,7 @@ jobs:
           echo "version=$LATEST" >> $GITHUB_OUTPUT
 
       - name: Setup Python ${{ steps.python-version.outputs.version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ steps.python-version.outputs.version }}
 

--- a/.github/workflows/build-wheels-defined.yml
+++ b/.github/workflows/build-wheels-defined.yml
@@ -99,7 +99,7 @@ jobs:
     needs: get-supported-versions
     name: windows x86_64
     if: ${{ inputs.os_windows_latest }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
@@ -254,10 +254,13 @@ jobs:
             -w /work \
             -e GH_TOKEN="${GH_TOKEN}" \
             -e PIP_NO_CACHE_DIR=1 \
+            -e PIP_INDEX_URL=https://www.piwheels.org/simple \
+            -e PIP_EXTRA_INDEX_URL=https://pypi.org/simple \
             python:${{ matrix.python-version }}-bookworm \
             bash -c "
               set -e
               python --version
+              source os_dependencies/linux_armv7_docker_prepare.sh
               # Install pip packages without cache to reduce memory usage
               python -m pip install --no-cache-dir --upgrade pip
               python -m pip install --no-cache-dir -r build_requirements.txt
@@ -339,10 +342,13 @@ jobs:
             -w /work \
             -e GH_TOKEN="${GH_TOKEN}" \
             -e PIP_NO_CACHE_DIR=1 \
+            -e PIP_INDEX_URL=https://www.piwheels.org/simple \
+            -e PIP_EXTRA_INDEX_URL=https://pypi.org/simple \
             python:${{ matrix.python-version }}-bullseye \
             bash -c "
               set -e
               python --version
+              source os_dependencies/linux_armv7_docker_prepare.sh
               # Install pip packages without cache to reduce memory usage
               python -m pip install --no-cache-dir --upgrade pip
               python -m pip install --no-cache-dir -r build_requirements.txt

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -31,7 +31,8 @@ jobs:
           - Linux ARMv7 Legacy
         include:
           - os: Windows
-            runner: windows-latest
+            # VS 2022 / v143 required (bleak-winrt); windows-latest is VS 2026 from ~Jun 2026
+            runner: windows-2022
             arch: windows-x86_64
           - os: Linux x86_64
             runner: ubuntu-latest
@@ -117,6 +118,27 @@ jobs:
         if: matrix.os == 'Windows'
         run: powershell -ExecutionPolicy Bypass -File os_dependencies/windows.ps1
 
+      - name: Locate Visual Studio 2022
+        if: matrix.os == 'Windows'
+        id: vs2022
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $path = & $vswhere -version "[17.0,18.0)" -latest -property installationPath
+          if (-not $path) {
+            throw "Visual Studio 2022 (17.x) not found on this runner."
+          }
+          Write-Host "Using Visual Studio at: $path"
+          "path=$path" >> $env:GITHUB_OUTPUT
+
+      - name: Enable MSVC developer environment
+        if: matrix.os == 'Windows'
+        uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: x64
+          # bleak-winrt (scikit-build) rejects MSVC 19.50 when probing VS 2022 generators
+          vs-path: ${{ steps.vs2022.outputs.path }}
+
       - name: Build wheels for IDF - ARMv7 (in Docker)
         if: matrix.os == 'Linux ARMv7'
         run: |
@@ -127,10 +149,13 @@ jobs:
             -e MIN_IDF_MINOR_VERSION=${{ needs.get-supported-versions.outputs.min_idf_minor_version }} \
             -e GH_TOKEN="${GH_TOKEN}" \
             -e PIP_NO_CACHE_DIR=1 \
+            -e PIP_INDEX_URL=https://www.piwheels.org/simple \
+            -e PIP_EXTRA_INDEX_URL=https://pypi.org/simple \
             python:${{ matrix.python-version }}-bookworm \
             bash -c "
               set -e
               python --version
+              source os_dependencies/linux_armv7_docker_prepare.sh
               # Install pip packages without cache to reduce memory usage
               python -m pip install --no-cache-dir --upgrade pip
               python -m pip install --no-cache-dir -r build_requirements.txt
@@ -152,10 +177,13 @@ jobs:
             -e MIN_IDF_MINOR_VERSION=${{ needs.get-supported-versions.outputs.min_idf_minor_version }} \
             -e GH_TOKEN="${GH_TOKEN}" \
             -e PIP_NO_CACHE_DIR=1 \
+            -e PIP_INDEX_URL=https://www.piwheels.org/simple \
+            -e PIP_EXTRA_INDEX_URL=https://pypi.org/simple \
             python:${{ matrix.python-version }}-bullseye \
             bash -c "
               set -e
               python --version
+              source os_dependencies/linux_armv7_docker_prepare.sh
               # Install pip packages without cache to reduce memory usage
               python -m pip install --no-cache-dir --upgrade pip
               python -m pip install --no-cache-dir -r build_requirements.txt

--- a/.github/workflows/build-wheels-platforms.yml
+++ b/.github/workflows/build-wheels-platforms.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Set up QEMU for ARMv7
         if: matrix.os == 'Linux ARMv7' || matrix.os == 'Linux ARMv7 Legacy'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm/v7
 
@@ -74,7 +74,7 @@ jobs:
 
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set IDF version environment variables
         run: |
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Python
         # Skip setting python on ARM because of missing compatibility: https://github.com/actions/setup-python/issues/108
         if: matrix.os != 'Linux ARMv7' && matrix.os != 'Linux ARMv7 Legacy'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -214,14 +214,14 @@ jobs:
         run: sudo chown -R $USER:$USER ./downloaded_wheels
 
       - name: Upload artifacts of downloaded_wheels directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-download-directory-${{ matrix.arch }}-${{ matrix.python-version }}
           path: ./downloaded_wheels
           retention-days: 1
 
       - name: Upload artifacts of Python version dependent wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dependent_requirements_${{ matrix.arch }}
           path: ./dependent_requirements.txt
@@ -261,7 +261,7 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get latest Python version
         id: python-version
@@ -271,7 +271,7 @@ jobs:
           echo "version=$LATEST" >> $GITHUB_OUTPUT
 
       - name: Setup Python ${{ steps.python-version.outputs.version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ steps.python-version.outputs.version }}
 

--- a/.github/workflows/build-wheels-python-dependent.yml
+++ b/.github/workflows/build-wheels-python-dependent.yml
@@ -78,17 +78,17 @@ jobs:
     steps:
       - name: Set up QEMU for ARMv7
         if: matrix.os == 'Linux ARMv7' || matrix.os == 'Linux ARMv7 Legacy'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm/v7
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
         # Skip setting python on ARMv7 (runs in Docker)
         if: matrix.os != 'Linux ARMv7' && matrix.os != 'Linux ARMv7 Legacy'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
             python-version: ${{ matrix.python-version }}
 
@@ -140,7 +140,7 @@ jobs:
           vs-path: ${{ steps.vs2022.outputs.path }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dependent_requirements_${{ matrix.arch }}
           path: dependent_requirements_${{ matrix.arch }}
@@ -225,7 +225,7 @@ jobs:
         run: sudo chown -R $USER:$USER ./downloaded_wheels
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-download-directory-${{ matrix.arch }}-${{ matrix.python-version }}
           if-no-files-found: ignore

--- a/.github/workflows/build-wheels-python-dependent.yml
+++ b/.github/workflows/build-wheels-python-dependent.yml
@@ -33,7 +33,8 @@ jobs:
           - Linux ARMv7 Legacy
         include:
           - os: Windows
-            runner: windows-latest
+            # VS 2022 / v143 required (bleak-winrt); windows-latest is VS 2026 from ~Jun 2026
+            runner: windows-2022
             arch: windows-x86_64
           - os: Linux x86_64
             runner: ubuntu-latest
@@ -117,6 +118,27 @@ jobs:
         if: matrix.os == 'Windows'
         run: powershell -ExecutionPolicy Bypass -File os_dependencies/windows.ps1
 
+      - name: Locate Visual Studio 2022
+        if: matrix.os == 'Windows'
+        id: vs2022
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $path = & $vswhere -version "[17.0,18.0)" -latest -property installationPath
+          if (-not $path) {
+            throw "Visual Studio 2022 (17.x) not found on this runner."
+          }
+          Write-Host "Using Visual Studio at: $path"
+          "path=$path" >> $env:GITHUB_OUTPUT
+
+      - name: Enable MSVC developer environment
+        if: matrix.os == 'Windows'
+        uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: x64
+          # bleak-winrt (scikit-build) rejects MSVC 19.50 when probing VS 2022 generators
+          vs-path: ${{ steps.vs2022.outputs.path }}
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -140,10 +162,13 @@ jobs:
             -e PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
             -e GH_TOKEN="${GH_TOKEN}" \
             -e PIP_NO_CACHE_DIR=1 \
+            -e PIP_INDEX_URL=https://www.piwheels.org/simple \
+            -e PIP_EXTRA_INDEX_URL=https://pypi.org/simple \
             python:${{ matrix.python-version }}-bookworm \
             bash -c "
               set -e
               python --version
+              source os_dependencies/linux_armv7_docker_prepare.sh
               # Install pip packages without cache to reduce memory usage
               python -m pip install --no-cache-dir --upgrade pip
               python -m pip install --no-cache-dir -r build_requirements.txt
@@ -163,10 +188,13 @@ jobs:
             -e PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
             -e GH_TOKEN="${GH_TOKEN}" \
             -e PIP_NO_CACHE_DIR=1 \
+            -e PIP_INDEX_URL=https://www.piwheels.org/simple \
+            -e PIP_EXTRA_INDEX_URL=https://pypi.org/simple \
             python:${{ matrix.python-version }}-bullseye \
             bash -c "
               set -e
               python --version
+              source os_dependencies/linux_armv7_docker_prepare.sh
               # Install pip packages without cache to reduce memory usage
               python -m pip install --no-cache-dir --upgrade pip
               python -m pip install --no-cache-dir -r build_requirements.txt

--- a/.github/workflows/only-create-and-upload-index.yml
+++ b/.github/workflows/only-create-and-upload-index.yml
@@ -17,7 +17,7 @@ jobs:
       PREFIX: 'pypi'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         run: python -m pip install -r build_requirements.txt

--- a/.github/workflows/test-wheels-install.yml
+++ b/.github/workflows/test-wheels-install.yml
@@ -57,23 +57,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU for ARMv7
         if: matrix.os == 'Linux ARMv7' || matrix.os == 'Linux ARMv7 Legacy'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm/v7
 
       - name: Download all repaired wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wheels-repaired-all
           path: ./downloaded_wheels
 
       - name: Setup Python
         if: matrix.os != 'Linux ARMv7' && matrix.os != 'Linux ARMv7 Legacy'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -120,7 +120,7 @@ jobs:
       # After test_wheels_install.py, ./downloaded_wheels contains only wheels for this
       # matrix Python + platform (see prune step in test_wheels_install.main).
       - name: Upload tested wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-tested-${{ matrix.arch }}-${{ matrix.python-version }}
           path: ./downloaded_wheels/*.whl

--- a/.github/workflows/test-wheels-install.yml
+++ b/.github/workflows/test-wheels-install.yml
@@ -29,7 +29,7 @@ jobs:
           - Linux ARMv7 Legacy
         include:
           - os: Windows
-            runner: windows-latest
+            runner: windows-2022
             arch: windows-x86_64
           - os: Linux x86_64
             runner: ubuntu-latest
@@ -93,7 +93,9 @@ jobs:
             -w /work \
             python:${{ matrix.python-version }}-bookworm \
             bash -c "
+              set -e
               python --version
+              source os_dependencies/linux_armv7_docker_prepare.sh
               python -m pip install --upgrade pip
               pip install -r build_requirements.txt
               python test_wheels_install.py
@@ -107,12 +109,16 @@ jobs:
             -w /work \
             python:${{ matrix.python-version }}-bullseye \
             bash -c "
+              set -e
               python --version
+              source os_dependencies/linux_armv7_docker_prepare.sh
               python -m pip install --upgrade pip
               pip install -r build_requirements.txt
               python test_wheels_install.py
             "
 
+      # After test_wheels_install.py, ./downloaded_wheels contains only wheels for this
+      # matrix Python + platform (see prune step in test_wheels_install.main).
       - name: Upload tested wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,10 +22,10 @@ jobs:
         python-version: ${{ fromJson(needs.get-supported-versions.outputs.supported_python) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -47,7 +47,7 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get latest Python version
         id: python-version
@@ -57,7 +57,7 @@ jobs:
           echo "version=$LATEST" >> $GITHUB_OUTPUT
 
       - name: Setup Python ${{ steps.python-version.outputs.version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ steps.python-version.outputs.version }}
 

--- a/.github/workflows/update-python-versions.yml
+++ b/.github/workflows/update-python-versions.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/upload-python-wheels.yml
+++ b/.github/workflows/upload-python-wheels.yml
@@ -29,13 +29,13 @@ jobs:
       PREFIX: 'pypi'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         run: python -m pip install -r build_requirements.txt
 
       - name: Download tested wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-tested-*
           path: ./downloaded_wheels

--- a/.github/workflows/wheels-repair.yml
+++ b/.github/workflows/wheels-repair.yml
@@ -26,7 +26,7 @@ jobs:
           - Linux ARMv7 Legacy
         include:
           - platform: Windows
-            runner: windows-latest
+            runner: windows-2022
             tool: delvewheel
             arch: windows-x86_64
           - platform: macOS ARM
@@ -161,6 +161,9 @@ jobs:
         run: |
           docker run --rm \
             --platform ${{ matrix.docker_platform }} \
+            -e AUDITWHEEL_PLAT=manylinux_2_36_armv7l \
+            -e AUDITWHEEL_ONLY_PLAT=1 \
+            -e AUDITWHEEL_ALLOW_LINUX_TAG=1 \
             -v $(pwd):/work \
             -w /work \
             ${{ matrix.docker_image }} \
@@ -177,6 +180,9 @@ jobs:
         run: |
           docker run --rm \
             --platform ${{ matrix.docker_platform }} \
+            -e AUDITWHEEL_PLAT=manylinux_2_31_armv7l \
+            -e AUDITWHEEL_ONLY_PLAT=1 \
+            -e AUDITWHEEL_ALLOW_LINUX_TAG=1 \
             -v $(pwd):/work \
             -w /work \
             ${{ matrix.docker_image }} \
@@ -201,12 +207,26 @@ jobs:
     needs: repair-wheels
     runs-on: ubuntu-latest
     steps:
-      - name: Download all repaired wheels
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Download each wheels-repaired-* artifact into its own subdirectory so
+      # same-named wheels from ARMv7 vs ARMv7 Legacy are not silently overwritten
+      # before ARMv7-specific collision detection or S3 upload (see README: ARMv7 wheel collisions).
+      - name: Download all repaired wheels (per-artifact subdirectories)
         uses: actions/download-artifact@v4
         with:
           pattern: wheels-repaired-*
-          path: ./all_wheels
-          merge-multiple: true
+          path: ./all_wheels_staging
+          merge-multiple: false
+
+      - name: Check for ARMv7 vs ARMv7 Legacy wheel basename clash
+        run: python3 check_wheel_collisions.py ./all_wheels_staging
+
+      - name: Flatten merged wheels directory
+        run: |
+          mkdir -p ./all_wheels
+          find ./all_wheels_staging -type f -name '*.whl' -exec cp -f {} ./all_wheels/ \;
 
       - name: List merged wheels
         run: |

--- a/.github/workflows/wheels-repair.yml
+++ b/.github/workflows/wheels-repair.yml
@@ -71,10 +71,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           # Download only artifacts for this specific architecture to avoid mixing wheels
           # (especially important for ARMv7 vs ARMv7 Legacy which produce same-named wheels)
@@ -96,13 +96,13 @@ jobs:
 
       - name: Setup Python
         if: steps.check-wheels.outputs.has_wheels == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Set up QEMU
         if: matrix.setup_qemu && steps.check-wheels.outputs.has_wheels == 'true'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: ${{ matrix.qemu_platform }}
 
@@ -195,7 +195,7 @@ jobs:
 
       - name: Re-upload artifacts with repaired wheels
         if: steps.check-wheels.outputs.has_wheels == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-repaired-${{ matrix.arch }}
           path: ./downloaded_wheels
@@ -208,13 +208,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Download each wheels-repaired-* artifact into its own subdirectory so
       # same-named wheels from ARMv7 vs ARMv7 Legacy are not silently overwritten
       # before ARMv7-specific collision detection or S3 upload (see README: ARMv7 wheel collisions).
       - name: Download all repaired wheels (per-artifact subdirectories)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-repaired-*
           path: ./all_wheels_staging
@@ -234,7 +234,7 @@ jobs:
           find ./all_wheels -name "*.whl" | wc -l
 
       - name: Upload merged wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-repaired-all
           path: ./all_wheels

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ The repair tools are used after build to link and bundle all the needed librarie
 
 This logic is done by the [repair workflow](./.github/workflows/wheels-repair.yml) and the [`repair_wheels.py` script](./repair_wheels.py)
 
+### ARMv7 vs ARMv7 Legacy: same wheel filename, different binaries
+
+`Linux ARMv7` and `Linux ARMv7 Legacy` can both produce a wheel whose **filename is identical** (same PEP 425 tags) while the **ELF contents differ** (different glibc/OpenSSL/Rust toolchain lineage). **Note:** `wheels-download-directory-*` CI artifacts are the **pre-repair** build outputs; comparing those can still show identical names until the [repair workflow](./.github/workflows/wheels-repair.yml) runs. Two bad outcomes follow if that is not handled after repair/merge:
+
+1. **Artifact merge / local flatten** — downloading multiple `wheels-repaired-*` artifacts into one directory with `merge-multiple: true` can make the second file **silently overwrite** the first on disk before any upload runs.
+2. **S3 upload** — [`upload_wheels.py`](./upload_wheels.py) publishes to `pypi/<package>/<wheel-filename>`. Uploading a second wheel with the **same key** replaces the object; clients then see whichever build ran last. ARMv7 vs Legacy clashes must be caught **before** upload (merge collision check and distinct `manylinux_*_armv7l` tags when auditwheel allows), not by refusing re-uploads of an existing key when wheel bytes change between CI runs.
+
+Mitigations in this repo:
+
+- Repair sets **`AUDITWHEEL_PLAT`** and **`AUDITWHEEL_ONLY_PLAT`** per lineage (`manylinux_2_36_armv7l` vs `manylinux_2_31_armv7l`) so [`repair_wheels.py`](./repair_wheels.py) runs `auditwheel repair --plat ... --only-plat` and emitted wheels get **distinct single-tag filenames** when auditwheel supports it. If **`AUDITWHEEL_PLAT` is set**, ARMv7 “libc detection failed” outcomes are **not** treated as non-fatal skips (that would leave identical filenames across lineages).
+- The repair workflow merges repaired artifacts using **per-artifact subdirectories**, then runs [`check_wheel_collisions.py`](./check_wheel_collisions.py) to **fail CI** only if the same `*.whl` basename appears with **different contents** under **both** `wheels-repaired-linux-armv7` and `wheels-repaired-linux-armv7legacy` **and** the wheel is not a pure universal (`platform` tag `any` only; those ZIPs can legitimately differ between lineages). Other duplicate basenames across macOS runners or pure-Python wheels are expected and are ignored, before flattening for tests/upload.
+
 ## Activity Diagram
 The main file is `build-wheels-platforms.yml` which is scheduled to run periodically to build Python wheels for any requirement of all [ESP-IDF]-supported versions.
 
@@ -166,5 +178,8 @@ Docker files are in its own repository where there are build and published from.
 - ARMv7 runner (older OSes) - [manylinux_armv7_legacy](https://github.com/espressif/github-esp-dockerfiles/pkgs/container/github-esp-dockerfiles%2Fidf-python-wheels-armv7l-legacy)
     - For older ARMv7 operating systems
     - For packages requiring glibc 2.31
+
+> [!WARNING]
+> piwheels may rely on system-provided shared libraries (i.e. may not bundle `.libs/`). If a target OS is missing those libraries or has an incompatible version, imports may fail at runtime.
 
 [ESP-IDF]: https://github.com/espressif/esp-idf

--- a/_helper_functions.py
+++ b/_helper_functions.py
@@ -37,19 +37,10 @@ from packaging.version import InvalidVersion
 from packaging.version import Version
 from packaging.version import parse as parse_version
 
-# Packages that should be built from source on Linux to ensure correct library linking
-# These packages often have pre-built wheels on PyPI that link against different library versions
-# NOTE: This only applies to Linux (especially ARM) - Windows and macOS pre-built wheels work fine
-# NOTE: Do NOT add packages with Rust components (cryptography, pynacl, bcrypt) here
-# as they have complex build requirements and may not support all Python versions
-FORCE_SOURCE_BUILD_PACKAGES_LINUX = [
-    "cffi",
-    "pillow",
-    "pyyaml",
-    "brotli",
-    "greenlet",
-    "bitarray",
-]
+# Linux ``--no-binary`` names: one per line in ``force_no_binary_linux.txt`` (also ``PIP_NO_BINARY`` in ARMv7 Docker).
+
+_REPO_ROOT = Path(__file__).resolve().parent
+FORCE_NO_BINARY_LINUX_FILE = "force_no_binary_linux.txt"
 
 EXCLUDE_LIST_PATH = "exclude_list.yaml"
 
@@ -105,6 +96,8 @@ def wheel_archive_is_readable(path: Path) -> bool:
 _PYPI_REQUIRES_PYTHON_CACHE: Dict[Tuple[str, str], Optional[str]] = {}
 # Full project JSON per canonical package name; None means fetch failed (cached)
 _PYPI_PROJECT_JSON_CACHE: Dict[str, Optional[Dict[str, Any]]] = {}
+# force_no_binary_linux.txt: resolved repo root -> (names, normalized names for lookup)
+_FORCE_NO_BINARY_LINUX_CACHE: Dict[Path, Tuple[List[str], frozenset[str]]] = {}
 
 
 def _pypi_user_agent() -> str:
@@ -255,6 +248,38 @@ def exclude_entry_applies_to_platform(entry: dict, current_platform: str) -> boo
     return False
 
 
+def load_force_no_binary_linux_names(repo_root: Path | None = None) -> list[str]:
+    """Package names for Linux ``--no-binary`` / ``PIP_NO_BINARY`` (``force_no_binary_linux.txt``)."""
+    root = (repo_root if repo_root is not None else _REPO_ROOT).resolve()
+    cached = _FORCE_NO_BINARY_LINUX_CACHE.get(root)
+    if cached is not None:
+        return cached[0]
+    path = root / FORCE_NO_BINARY_LINUX_FILE
+    out: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            out.append(line)
+    if not out:
+        raise ValueError(f"{path}: need at least one non-comment package name")
+    normalized = frozenset(pkg.lower().replace("-", "_") for pkg in out)
+    _FORCE_NO_BINARY_LINUX_CACHE[root] = (out, normalized)
+    return out
+
+
+def _force_no_binary_linux_normalized(repo_root: Path | None = None) -> frozenset[str]:
+    """
+    Normalized package names from ``force_no_binary_linux.txt``
+    (cached with ``load_force_no_binary_linux_names``).
+    """
+    root = (repo_root if repo_root is not None else _REPO_ROOT).resolve()
+    cached = _FORCE_NO_BINARY_LINUX_CACHE.get(root)
+    if cached is not None:
+        return cached[1]
+    load_force_no_binary_linux_names(root)
+    return _FORCE_NO_BINARY_LINUX_CACHE[root][1]
+
+
 def get_no_binary_args(requirement_name: str) -> list:
     """Get --no-binary arguments if this package should be built from source.
 
@@ -277,10 +302,28 @@ def get_no_binary_args(requirement_name: str) -> list:
         return []
     pkg_name = match.group(1).lower().replace("-", "_")
 
-    for pkg in FORCE_SOURCE_BUILD_PACKAGES_LINUX:
-        if pkg.lower().replace("-", "_") == pkg_name:
-            return ["--no-binary", match.group(1)]
+    if pkg_name in _force_no_binary_linux_normalized(_REPO_ROOT):
+        return ["--no-binary", match.group(1)]
     return []
+
+
+def get_pip_wheel_extra_args(requirement_name: str) -> list[str]:
+    """Extra ``pip wheel`` CLI flags for packages with known CI build quirks.
+
+    ``bleak-winrt`` 1.2.0 uses legacy ``scikit-build``, whose MSVC probe only accepts
+    the compiler version band for the generator it tries (e.g. 1930–1949 for VS 2022).
+    GHA ``windows-latest`` can expose VS 2025 (MSVC 19.50) by default, which fails that
+    probe when building from the sdist under PEP 517 isolation. Use the host env
+    (after ``setup-msvc-dev`` on ``windows-2022`` with VS 17.x) and ``--no-build-isolation``.
+    """
+    if platform.system() != "Windows":
+        return []
+    match = re.match(r"^([a-zA-Z0-9_.-]+)", str(requirement_name).strip())
+    if not match:
+        return []
+    if canonicalize_name(match.group(1)) != canonicalize_name("bleak-winrt"):
+        return []
+    return ["--no-build-isolation"]
 
 
 def _safe_text_for_stdout(text: str) -> str:

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -19,3 +19,7 @@ setuptools-scm>=6.2,<9      # Required by packages using git-based versioning
 setuptools-rust>=1.5.0,<2   # Required by packages with Rust extensions (e.g., cryptography, bleak, rpds-py)
 cython>=0.29.0              # Required by packages using Cython (e.g., coverage, pyyaml speedups)
 poetry-core>=1.0.0          # Required as build backend for packages using Poetry
+# bleak-winrt (scikit-build) on Windows: used with --no-build-isolation in CI
+scikit-build>=0.18.0
+cmake>=3.16
+ninja>=1.10

--- a/build_wheels_from_file.py
+++ b/build_wheels_from_file.py
@@ -17,6 +17,7 @@ from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
 from _helper_functions import get_no_binary_args
+from _helper_functions import get_pip_wheel_extra_args
 from _helper_functions import print_color
 from _helper_functions import pypi_requires_python_preflight_skip
 
@@ -136,6 +137,7 @@ if requirements_dir:
             continue
         # Get no-binary args for packages that should be built from source
         no_binary_args = get_no_binary_args(requirement)
+        extra_pip_args = get_pip_wheel_extra_args(requirement)
         force_interpreter_args = (
             _force_interpreter_no_binary_args(requirement)
             if _apply_force_interpreter_binary(args.force_interpreter_binary)
@@ -155,6 +157,7 @@ if requirements_dir:
                 "downloaded_wheels",
             ]
             + no_binary_args
+            + extra_pip_args
             + force_interpreter_args,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -189,6 +192,7 @@ else:
             continue
         # Get no-binary args for packages that should be built from source
         no_binary_args = get_no_binary_args(requirement)
+        extra_pip_args = get_pip_wheel_extra_args(requirement)
         force_interpreter_args = (
             _force_interpreter_no_binary_args(requirement)
             if _apply_force_interpreter_binary(args.force_interpreter_binary)
@@ -208,6 +212,7 @@ else:
                 "downloaded_wheels",
             ]
             + no_binary_args
+            + extra_pip_args
             + force_interpreter_args,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/check_wheel_collisions.py
+++ b/check_wheel_collisions.py
@@ -1,0 +1,143 @@
+#
+# SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Detect ARMv7 vs ARMv7 Legacy wheel basename clashes under a merged tree.
+
+Used after downloading per-arch ``wheels-repaired-*`` artifacts into separate
+subdirectories (``merge-multiple: false``). The same ``*.whl`` basename can also
+appear under other pairs of trees (for example ``py3-none-any`` rebuilt on every
+runner, or ``macosx_*_universal2`` repaired on both macOS jobs); those may
+legitimately differ by hash and are **not** errors here. Only collisions between
+**Linux ARMv7** and **Linux ARMv7 Legacy** lineages are fatal — see README
+(ARMv7 vs ARMv7 Legacy). Pure universal wheels (platform tag ``any`` only) are
+skipped even under ARMv7 vs Legacy, because ZIP digests can differ without a
+native binary lineage conflict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+
+from collections import defaultdict
+from pathlib import Path
+
+from packaging.utils import InvalidWheelFilename
+from packaging.utils import parse_wheel_filename
+
+# Top-level directory names under the staging root (matches upload-artifact names
+# in wheels-repair.yml). Tests use shorter stand-ins.
+_ARMV7_STAGING_DIRS = frozenset(
+    {
+        "wheels-repaired-linux-armv7",
+        "linux-armv7",
+    }
+)
+_ARMV7_LEGACY_STAGING_DIRS = frozenset(
+    {
+        "wheels-repaired-linux-armv7legacy",
+        "linux-armv7legacy",
+    }
+)
+
+
+def _armv7_lineage(path: Path, root: Path) -> str | None:
+    """Return ``armv7``, ``armv7legacy``, or None based on the first path segment under root."""
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        return None
+    if len(rel.parts) < 2:
+        return None
+    top = rel.parts[0]
+    if top in _ARMV7_STAGING_DIRS:
+        return "armv7"
+    if top in _ARMV7_LEGACY_STAGING_DIRS:
+        return "armv7legacy"
+    return None
+
+
+def _is_pure_universal_wheel(filename: str) -> bool:
+    """True if every build tag in the wheel is ``*-none-any`` / ``*-py2.py3-none-any`` style.
+
+    Such wheels are not Linux-ARM-specific binaries; ARMv7 vs Legacy repair often
+    produces different ZIP bytes (metadata, tool versions) without a glibc/ELF
+    lineage conflict that this check is meant to catch.
+    """
+    try:
+        _name, _version, _build, tags = parse_wheel_filename(filename)
+    except InvalidWheelFilename:
+        return False
+    return bool(tags) and all(tag.platform == "any" for tag in tags)
+
+
+def _sha256_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            b = f.read(chunk_size)
+            if not b:
+                break
+            h.update(b)
+    return h.hexdigest()
+
+
+def collect_collision_errors(root: Path) -> list[str]:
+    """Return human-readable error lines; empty if OK.
+
+    Only reports when the same basename appears under **both** ARMv7 and ARMv7
+    Legacy staging trees with **more than one** distinct file digest across
+    those two trees, and the wheel is **not** a pure universal (``platform`` tag
+    ``any`` only) artifact.
+    """
+    wheels: list[Path] = []
+    for p in sorted(root.rglob("*.whl")):
+        if p.is_file():
+            wheels.append(p)
+
+    by_name: defaultdict[str, list[Path]] = defaultdict(list)
+    for p in wheels:
+        by_name[p.name].append(p)
+
+    errors: list[str] = []
+    for name, paths in sorted(by_name.items()):
+        armv7 = [p for p in paths if _armv7_lineage(p, root) == "armv7"]
+        legacy = [p for p in paths if _armv7_lineage(p, root) == "armv7legacy"]
+        if not armv7 or not legacy:
+            continue
+        if _is_pure_universal_wheel(name):
+            continue
+        lineage_paths = armv7 + legacy
+        by_digest: defaultdict[str, list[Path]] = defaultdict(list)
+        for p in lineage_paths:
+            by_digest[_sha256_file(p)].append(p)
+        if len(by_digest) == 1:
+            continue
+        lines = [f"ARMv7 vs ARMv7 Legacy wheel basename clash (different contents): {name}"]
+        for digest, ps in sorted(by_digest.items()):
+            for p in ps:
+                lines.append(f"  - {p}  sha256={digest}")
+        errors.append("\n".join(lines))
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    root = Path(argv[1] if len(argv) > 1 else ".").resolve()
+    if not root.is_dir():
+        print(f"Error: not a directory: {root}", file=sys.stderr)
+        return 2
+
+    errors = collect_collision_errors(root)
+    if errors:
+        print("Wheel basename collision check failed:\n", file=sys.stderr)
+        for block in errors:
+            print(block, file=sys.stderr)
+            print(file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/force_no_binary_linux.txt
+++ b/force_no_binary_linux.txt
@@ -1,0 +1,9 @@
+# Linux: pip PIP_NO_BINARY / per-wheel --no-binary (ARMv7 Docker + build_wheels on Linux)
+cffi
+# PyPI maturin manylinux wheels need newer glibc than Debian bookworm/bullseye armhf; sdist uses setuptools-rust.
+maturin
+pillow
+pyyaml
+brotli
+greenlet
+bitarray

--- a/include_list.yaml
+++ b/include_list.yaml
@@ -1,5 +1,7 @@
 # List of Python packages to additionally include to the automatically assembled requirements
-#"For assembled <main requirements> additionally include <package_name> with <version> on <platform> for <python> version".
+# "For assembled <main requirements> additionally include <package_name> with <version> on <platform> for <python> version".
+#
+# Linux packages to build from wheels (pip --no-binary): see force_no_binary_linux.txt
 
 # include_list template
 #- package_name: '<name_of_package>'

--- a/os_dependencies/linux_arm.sh
+++ b/os_dependencies/linux_arm.sh
@@ -85,6 +85,15 @@ if [ "$arch" == "armv7l" ]; then
     apt remove --auto-remove --purge rust-gdb rustc libstd-rust-dev libstd-rust-1.48 2>/dev/null || true
     # install Rust dependencies
     apt-get install -y libssl-dev libffi-dev gcc musl-dev
+    # Match linux_armv7_docker_prepare.sh: Bookworm armhf has libffi.so.8 only; binary cffi wheels
+    # may still dlopen libffi.so.7 (pip build isolation, piwheels/PyPI manylinux tags).
+    for _ffi_libdir in /usr/lib/arm-linux-gnueabihf /usr/lib/arm-linux-gnueabi; do
+      if [ -d "$_ffi_libdir" ] && [ -f "$_ffi_libdir/libffi.so.8" ] && [ ! -e "$_ffi_libdir/libffi.so.7" ]; then
+        ln -sfn libffi.so.8 "$_ffi_libdir/libffi.so.7"
+        ldconfig 2>/dev/null || true
+        break
+      fi
+    done
     # install Rust
     curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | bash -s -- -y
     . $HOME/.cargo/env

--- a/os_dependencies/linux_armv7_docker_prepare.sh
+++ b/os_dependencies/linux_armv7_docker_prepare.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Minimal OS setup for ARMv7 Docker builds *before* pip installs (build_requirements / wheels).
+# Expects to run as root (official python:*-bookworm / *-bullseye images).
+# Must be sourced (not subprocess bash) so PIP_NO_BINARY persists for later pip / PEP 517 builds.
+
+set -e
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Explicit libffi runtime matches the dev headers (bullseye: libffi7, bookworm: libffi8).
+# Piwheels manylinux cffi wheels can link against a newer libffi than the image ships;
+# pairing dev + runtime keeps installs predictable; PIP_NO_BINARY (force_no_binary_linux.txt)
+# forces source builds for those packages before build_requirements / wheels.
+. /etc/os-release
+case "${VERSION_CODENAME:-}" in
+  bullseye) LIBFFI_RUNTIME=libffi7 ;;
+  bookworm) LIBFFI_RUNTIME=libffi8 ;;
+  *)        LIBFFI_RUNTIME= ;;
+esac
+
+apt-get update -qq
+apt-get install -y --no-install-recommends \
+  ca-certificates \
+  libffi-dev \
+  libssl-dev
+if [ -n "$LIBFFI_RUNTIME" ]; then
+  apt-get install -y --no-install-recommends "$LIBFFI_RUNTIME"
+fi
+
+export PIP_NO_BINARY="$(
+  grep -vE '^[[:space:]]*#|^[[:space:]]*$' force_no_binary_linux.txt | tr '\n' ',' | sed 's/,$//'
+)"
+
+# Manylinux/piwheels cffi wheels on armhf still reference libffi.so.7. Debian Bookworm only
+# ships libffi.so.8, so "import _cffi_backend" fails inside pip's isolated build env
+# (e.g. argon2-cffi-bindings metadata). Bullseye typically already provides .so.7 via libffi7.
+arch=$(uname -m)
+if [ "$arch" = "armv7l" ]; then
+  for libdir in /usr/lib/arm-linux-gnueabihf /usr/lib/arm-linux-gnueabi; do
+    if [ -d "$libdir" ] && [ -f "$libdir/libffi.so.8" ] && [ ! -e "$libdir/libffi.so.7" ]; then
+      ln -sfn libffi.so.8 "$libdir/libffi.so.7"
+      ldconfig 2>/dev/null || true
+      break
+    fi
+  done
+fi

--- a/repair_wheels.py
+++ b/repair_wheels.py
@@ -12,6 +12,7 @@ See: https://github.com/espressif/idf-python-wheels/blob/main/README.md#universa
 - Linux: auditwheel (bundles SOs)
 """
 
+import os
 import platform
 import subprocess
 
@@ -94,6 +95,46 @@ def get_wheel_arch(wheel_name: str) -> Union[str, None]:
     return None
 
 
+def _only_plat_env_enabled() -> bool:
+    return os.environ.get("AUDITWHEEL_ONLY_PLAT", "").strip().lower() in ("1", "true", "yes")
+
+
+def _allow_linux_tag_env_enabled() -> bool:
+    """When true, allow keeping linux-tag wheels on ARMv7 even if --plat is set.
+
+    This is useful when resolution prefers piwheels, which may provide wheels
+    tagged as ``linux_armv7l`` that are not repairable to the desired manylinux
+    tag in our repair containers.
+    """
+    return os.environ.get("AUDITWHEEL_ALLOW_LINUX_TAG", "").strip().lower() in ("1", "true", "yes")
+
+
+def _is_linux_tag_wheel(wheel_name: str) -> bool:
+    wn = wheel_name.lower()
+    return "-linux_" in wn and "manylinux" not in wn and "musllinux" not in wn
+
+
+def _armv7_forced_plat_filename_ok(wheel_name: str, plat: str) -> bool:
+    """True if ``wheel_name`` matches ``AUDITWHEEL_PLAT`` for ARMv7 / ARMv7 Legacy splits.
+
+    When ``AUDITWHEEL_ONLY_PLAT`` is set, legacy wheels must not carry a ``manylinux_2_36``
+    tag (auditwheel dual-tag would collide with the standard lineage again).
+    """
+    plat_l = plat.lower()
+    wn = wheel_name.lower()
+    if _allow_linux_tag_env_enabled() and _is_linux_tag_wheel(wn):
+        return True
+    if "manylinux_2_36" in plat_l:
+        return "manylinux_2_36" in wn
+    if "manylinux_2_31" in plat_l and "manylinux_2_36" not in plat_l:
+        if "manylinux_2_31" not in wn:
+            return False
+        if _only_plat_env_enabled() and "manylinux_2_36" in wn:
+            return False
+        return True
+    return True
+
+
 def repair_wheel_windows(wheel_path: Path, temp_dir: Path) -> subprocess.CompletedProcess[str]:
     """Repair Windows wheel using delvewheel."""
     result = subprocess.run(
@@ -157,12 +198,28 @@ def repair_wheel_linux(wheel_path: Path, temp_dir: Path) -> subprocess.Completed
 
     Uses --strip option to strip debugging symbols which can help with
     ELF alignment issues on ARM (fixes "ELF load command address/offset not properly aligned" errors).
+
+    If ``AUDITWHEEL_PLAT`` is set (e.g. in CI for ARMv7 vs ARMv7 Legacy), it is passed as
+    ``auditwheel repair --plat ...`` so repaired wheels get distinct PEP 425 platform tags
+    when build lineages would otherwise emit the same filename.
     """
-    result = subprocess.run(
-        ["auditwheel", "repair", str(wheel_path), "-w", str(temp_dir), "--strip"],
-        capture_output=True,
-        text=True,
-    )
+    plat = os.environ.get("AUDITWHEEL_PLAT", "").strip()
+    only_plat = os.environ.get("AUDITWHEEL_ONLY_PLAT", "").strip().lower() in ("1", "true", "yes")
+
+    cmd = ["auditwheel", "repair", str(wheel_path), "-w", str(temp_dir), "--strip"]
+    if plat:
+        cmd.extend(["--plat", plat])
+    if only_plat:
+        cmd.append("--only-plat")
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    # Older auditwheel versions may not support --only-plat. If requested, retry once without it.
+    combined_err = (result.stderr or "") + (result.stdout or "")
+    if only_plat and result.returncode != 0 and "unrecognized arguments: --only-plat" in combined_err:
+        cmd_no_only = [c for c in cmd if c != "--only-plat"]
+        result = subprocess.run(cmd_no_only, capture_output=True, text=True)
+
     return result
 
 
@@ -250,7 +307,8 @@ def main() -> None:
             print_color(f"  {result.stderr.strip()}", Fore.RED)
 
         # Check for errors
-        error_msg = result.stderr.strip() if result.stderr else ""
+        # auditwheel may log failures on stdout or stderr depending on version / logging.
+        error_msg = ((result.stderr or "") + "\n" + (result.stdout or "")).strip()
 
         # Corrupt zip / bad central directory (delocate opens the wheel as a zip)
         if _stderr_indicates_bad_zip(error_msg):
@@ -289,9 +347,9 @@ def main() -> None:
 
                 # Update wheel reference and error message for subsequent checks
                 wheel = Path(renamed_wheel)
-                error_msg = result.stderr.strip() if result.stderr else ""
+                error_msg = ((result.stderr or "") + "\n" + (result.stdout or "")).strip()
 
-        # Special handling forLinux ARMv7 broken wheels
+        # Special handling for Linux ARMv7 broken wheels
         if (
             current_platform == "Linux"
             and current_arch == "armv7l"
@@ -302,16 +360,44 @@ def main() -> None:
             deleted_count += 1
             continue
 
+        plat_env = os.environ.get("AUDITWHEEL_PLAT", "").strip()
+        allow_linux_tag = _allow_linux_tag_env_enabled()
+        is_linux_tag = _is_linux_tag_wheel(wheel.name)
+        is_std_linux_arch = current_platform == "Linux" and current_arch in ("x86_64", "aarch64")
+
         # Check for non-critical errors (keep original wheel)
         is_noncritical = (
             "too-recent versioned symbols" in error_msg
             # manylinux wheel can't find its libraries
             # it means it was already properly repaired
-            or ("manylinux" in wheel.name and "could not be located" in error_msg)
+            or (("manylinux" in wheel.name and "could not be located" in error_msg) and not plat_env)
+            # Some upstream manylinux wheels ship with DT_NEEDED entries that reference already-hashed
+            # vendored libs (e.g. libbrotlicommon-<hash>.so.1). When our repair container can't
+            # locate that exact filename, we should keep the original wheel rather than failing
+            # the whole repair workflow (x86_64/aarch64 only; ARMv7 uses forced plat policy).
+            or (
+                is_std_linux_arch
+                and "manylinux" in wheel.name
+                and "Cannot repair wheel, because required library" in error_msg
+                and "could not be located" in error_msg
+            )
+            # When allowing linux-tag wheels (piwheels), treat missing graft libs as non-fatal
+            # and keep the original linux-tag wheel rather than failing the whole repair job.
+            or (
+                plat_env
+                and allow_linux_tag
+                and is_linux_tag
+                and (
+                    "Cannot repair wheel, because required library" in error_msg or "could not be located" in error_msg
+                )
+            )
             # ARMv7 CI runs under QEMU; auditwheel may fail libc detection on abi3/native .so
+            # When AUDITWHEEL_PLAT is set (ARMv7 vs ARMv7 Legacy), skipping repair would keep
+            # identical wheel filenames across lineages — do not treat libc detection as non-critical.
             or (
                 current_platform == "Linux"
                 and current_arch == "armv7l"
+                and not plat_env
                 and ("InvalidLibc" in error_msg or "couldn't detect libc" in error_msg)
             )
         )
@@ -335,15 +421,37 @@ def main() -> None:
                 print_color("  -> Keeping original wheel (build issue: needs older toolchain)", Fore.YELLOW)
             elif "manylinux" in wheel.name and "could not be located" in error_msg:
                 print_color("  -> Keeping original wheel (already bundled from PyPI)", Fore.GREEN)
+            elif plat_env and allow_linux_tag and is_linux_tag:
+                print_color(
+                    "  -> Keeping original wheel (linux-tag wheel; not forcing manylinux under current policy)",
+                    Fore.YELLOW,
+                )
             elif (
                 current_platform == "Linux"
                 and current_arch == "armv7l"
+                and not plat_env
                 and ("InvalidLibc" in error_msg or "couldn't detect libc" in error_msg)
             ):
                 print_color(
                     "  -> Keeping original wheel (auditwheel libc detection failed on ARMv7 runner; often QEMU)",
                     Fore.YELLOW,
                 )
+            if (
+                plat_env
+                and current_platform == "Linux"
+                and current_arch == "armv7l"
+                and not _armv7_forced_plat_filename_ok(wheel.name, plat_env)
+                and not (allow_linux_tag and is_linux_tag)
+            ):
+                msg = (
+                    f"Wheel filename does not match forced AUDITWHEEL_PLAT={plat_env!r} "
+                    f"after non-fatal repair path: {wheel.name}"
+                )
+                print_color(f"  -> ERROR: {msg}", Fore.RED)
+                errors.append(f"{wheel.name}: {msg}")
+                wheel.unlink(missing_ok=True)
+                error_count += 1
+                continue
             skipped_count += 1
         elif has_error:
             # Actual error occurred (even if a wheel was created, it may be broken)
@@ -374,10 +482,40 @@ def main() -> None:
                     print_color("  -> Deleting repaired output (not a valid / readable zip archive)", Fore.RED)
                     final_path.unlink(missing_ok=True)
                     deleted_count += 1
+                elif (
+                    plat_env
+                    and current_platform == "Linux"
+                    and current_arch == "armv7l"
+                    and not _armv7_forced_plat_filename_ok(final_path.name, plat_env)
+                    and not (allow_linux_tag and _is_linux_tag_wheel(final_path.name))
+                ):
+                    msg = (
+                        f"Repaired wheel filename does not match forced AUDITWHEEL_PLAT={plat_env!r}: {final_path.name}"
+                    )
+                    print_color(f"  -> ERROR: {msg}", Fore.RED)
+                    errors.append(f"{final_path.name}: {msg}")
+                    final_path.unlink(missing_ok=True)
+                    error_count += 1
                 else:
                     repaired_count += 1
             elif result.returncode == 0:
                 # No repaired wheel created, but command succeeded (already compatible)
+                if (
+                    plat_env
+                    and current_platform == "Linux"
+                    and current_arch == "armv7l"
+                    and not _armv7_forced_plat_filename_ok(wheel.name, plat_env)
+                    and not (allow_linux_tag and is_linux_tag)
+                ):
+                    msg = (
+                        "auditwheel reported success but left the wheel unchanged with a filename "
+                        f"that does not match AUDITWHEEL_PLAT={plat_env!r}: {wheel.name}"
+                    )
+                    print_color(f"  -> ERROR: {msg}", Fore.RED)
+                    errors.append(f"{wheel.name}: {msg}")
+                    wheel.unlink(missing_ok=True)
+                    error_count += 1
+                    continue
                 print_color("  -> Keeping original wheel (already compatible)", Fore.GREEN)
                 skipped_count += 1
             else:

--- a/test_build_wheels.py
+++ b/test_build_wheels.py
@@ -222,6 +222,52 @@ class TestWheelCompatibility(unittest.TestCase):
         self.assertTrue(self.is_wheel_compatible(f"cryptography-41.0.0-cp39-abi3-{tag}.whl", "39"))
 
 
+class TestPruneWheelsForArtifact(unittest.TestCase):
+    """``prune_wheels_not_for_current_python`` keeps per-matrix wheels for CI artifacts."""
+
+    def test_prune_removes_other_python_same_platform(self):
+        import tempfile
+
+        from test_wheels_install import prune_wheels_not_for_current_python
+
+        tag = _current_platform_wheel_tag()
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / f"drop-1.0-cp310-cp310-{tag}.whl").write_bytes(b"a")
+            (d / f"keep-1.0-cp311-cp311-{tag}.whl").write_bytes(b"b")
+            (d / "universal-1.0-py3-none-any.whl").write_bytes(b"c")
+
+            removed = prune_wheels_not_for_current_python("311", d)
+            self.assertEqual(removed, 1)
+            self.assertFalse((d / f"drop-1.0-cp310-cp310-{tag}.whl").exists())
+            self.assertTrue((d / f"keep-1.0-cp311-cp311-{tag}.whl").exists())
+            self.assertTrue((d / "universal-1.0-py3-none-any.whl").exists())
+
+
+class TestGetPipWheelExtraArgs(unittest.TestCase):
+    def test_bleak_winrt_windows_no_build_isolation(self) -> None:
+        from _helper_functions import get_pip_wheel_extra_args
+
+        with patch("_helper_functions.platform.system", return_value="Windows"):
+            self.assertEqual(
+                get_pip_wheel_extra_args("bleak-winrt==1.2.0"),
+                ["--no-build-isolation"],
+            )
+            self.assertEqual(get_pip_wheel_extra_args("bleak_winrt"), ["--no-build-isolation"])
+
+    @patch("_helper_functions.platform.system", return_value="Linux")
+    def test_bleak_winrt_not_on_linux(self, _sys: object) -> None:
+        from _helper_functions import get_pip_wheel_extra_args
+
+        self.assertEqual(get_pip_wheel_extra_args("bleak-winrt"), [])
+
+    @patch("_helper_functions.platform.system", return_value="Windows")
+    def test_other_packages_unchanged(self, _sys: object) -> None:
+        from _helper_functions import get_pip_wheel_extra_args
+
+        self.assertEqual(get_pip_wheel_extra_args("cryptography"), [])
+
+
 class TestParseWheelName(unittest.TestCase):
     """Test the parse_wheel_name function from _helper_functions.py."""
 

--- a/test_check_wheel_collisions.py
+++ b/test_check_wheel_collisions.py
@@ -1,0 +1,94 @@
+#
+# SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import tempfile
+import unittest
+
+from pathlib import Path
+
+import check_wheel_collisions as cwc
+
+
+class TestCheckWheelCollisions(unittest.TestCase):
+    def test_no_collision_unique_basenames(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "a").mkdir()
+            (root / "b").mkdir()
+            (root / "a" / "foo-1.0-py3-none-any.whl").write_bytes(b"a")
+            (root / "b" / "bar-1.0-py3-none-any.whl").write_bytes(b"b")
+            self.assertEqual(cwc.collect_collision_errors(root), [])
+
+    def test_collision_same_basename_different_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "linux-armv7").mkdir()
+            (root / "linux-armv7legacy").mkdir()
+            name = "pkg-1.0-cp39-cp39-linux_armv7l.whl"
+            (root / "linux-armv7" / name).write_bytes(b"v1")
+            (root / "linux-armv7legacy" / name).write_bytes(b"v2-different")
+            errs = cwc.collect_collision_errors(root)
+            self.assertEqual(len(errs), 1)
+            self.assertIn(name, errs[0])
+
+    def test_same_basename_identical_bytes_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "x").mkdir()
+            (root / "y").mkdir()
+            name = "same-1.0-py3-none-any.whl"
+            payload = b"identical"
+            (root / "x" / name).write_bytes(payload)
+            (root / "y" / name).write_bytes(payload)
+            self.assertEqual(cwc.collect_collision_errors(root), [])
+
+    def test_main_returns_one_on_collision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "linux-armv7").mkdir()
+            (root / "linux-armv7legacy").mkdir()
+            name = "dup-1.0-cp39-cp39-linux_armv7l.whl"
+            (root / "linux-armv7" / name).write_bytes(b"1")
+            (root / "linux-armv7legacy" / name).write_bytes(b"2")
+            self.assertEqual(cwc.main(["_", str(root)]), 1)
+
+    def test_collision_ci_artifact_directory_names(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "wheels-repaired-linux-armv7").mkdir()
+            (root / "wheels-repaired-linux-armv7legacy").mkdir()
+            name = "pkg-1.0-cp39-cp39-linux_armv7l.whl"
+            (root / "wheels-repaired-linux-armv7" / name).write_bytes(b"v1")
+            (root / "wheels-repaired-linux-armv7legacy" / name).write_bytes(b"v2-different")
+            errs = cwc.collect_collision_errors(root)
+            self.assertEqual(len(errs), 1)
+            self.assertIn(name, errs[0])
+
+    def test_pure_universal_wheel_digest_mismatch_ignored(self) -> None:
+        """py3-none-any (etc.) may differ between ARMv7 Docker lineages; not a fatal clash."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "linux-armv7").mkdir()
+            (root / "linux-armv7legacy").mkdir()
+            name = "charset_normalizer-3.4.7-py3-none-any.whl"
+            (root / "linux-armv7" / name).write_bytes(b"zip-a")
+            (root / "linux-armv7legacy" / name).write_bytes(b"zip-b")
+            self.assertEqual(cwc.collect_collision_errors(root), [])
+
+    def test_benign_same_basename_other_lineages_ignored(self) -> None:
+        """macOS x86 vs ARM repair trees (or any non-ARMv7 pair) may differ; not a merge failure."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "wheels-repaired-macos-arm64").mkdir()
+            (root / "wheels-repaired-macos-x86_64").mkdir()
+            name = "crypt-1.0-cp38-abi3-macosx_10_9_universal2.whl"
+            (root / "wheels-repaired-macos-arm64" / name).write_bytes(b"a")
+            (root / "wheels-repaired-macos-x86_64" / name).write_bytes(b"b")
+            self.assertEqual(cwc.collect_collision_errors(root), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_wheels_install.py
+++ b/test_wheels_install.py
@@ -9,6 +9,10 @@ This script finds and installs wheels compatible with the current Python version
 verifying that wheel files are valid and platform-compatible.
 It also checks wheels against exclude_list.yaml and removes incompatible ones.
 
+After a successful run, wheels that do not match this job's Python version and host
+platform are deleted from ``downloaded_wheels`` so CI ``wheels-tested-*`` artifacts
+do not carry the full multi-Python merge (only ``wheels-repaired-all`` is merged).
+
 Wheels are ZIP archives (PEP 427). pip opens them with the zipfile module; a
 BadZipFile / "Bad magic number" error means the bytes on disk are not a valid
 ZIP (truncated, corrupted, or not a wheel), not that ".whl" was mistaken for ".zip".
@@ -107,6 +111,29 @@ def find_compatible_wheels(python_version: str) -> list[Path]:
             wheels.append(wheel_path)
 
     return sorted(wheels)
+
+
+def prune_wheels_not_for_current_python(
+    python_version_tag: str,
+    wheels_dir: Path | None = None,
+) -> int:
+    """Remove ``*.whl`` files that are not compatible with this Python + platform.
+
+    CI downloads the full merged ``wheels-repaired-all`` tree into ``downloaded_wheels``,
+    then tests only compatible wheels. Without pruning, the subsequent
+    ``wheels-tested-<arch>-<py>`` artifact would still contain every cp/py tag from the
+    merge, which is misleading and huge. ``wheels_dir`` defaults to ``WHEELS_DIR`` for
+    production; tests may pass a temporary directory.
+    """
+    base = wheels_dir if wheels_dir is not None else WHEELS_DIR
+    if not base.exists():
+        return 0
+    removed = 0
+    for wheel_path in base.glob("*.whl"):
+        if not is_wheel_compatible(wheel_path.name, python_version_tag):
+            wheel_path.unlink(missing_ok=True)
+            removed += 1
+    return removed
 
 
 def install_wheel(wheel_path: Path) -> tuple[bool, str]:
@@ -276,6 +303,14 @@ def main() -> int:
         for wheel_name, _ in failed_wheels:
             print(f"  - {wheel_name}")
         return 1
+
+    pruned = prune_wheels_not_for_current_python(python_version_tag)
+    if pruned:
+        print_color(
+            f"Pruned {pruned} wheel(s) not for this matrix (Python {python_version} / "
+            f"current platform) before artifact upload",
+            Fore.YELLOW,
+        )
 
     print_color("\nAll compatible wheels processed successfully!", Fore.GREEN)
     return 0

--- a/upload_wheels.py
+++ b/upload_wheels.py
@@ -76,9 +76,10 @@ for full_path, wheel in wheel_paths:
         wheel_name = match.group(1)
         wheel_name = normalize(wheel_name)
 
-        is_new = f"pypi/{wheel_name}/{wheel}" not in existing_wheels
+        s3_key = f"pypi/{wheel_name}/{wheel}"
+        is_new = s3_key not in existing_wheels
 
-        BUCKET.upload_file(full_path, f"pypi/{wheel_name}/{wheel}", ExtraArgs={"ACL": "public-read"})
+        BUCKET.upload_file(full_path, s3_key, ExtraArgs={"ACL": "public-read"})
 
         if is_new:
             new_wheels += 1

--- a/verify_s3_wheels.py
+++ b/verify_s3_wheels.py
@@ -15,6 +15,8 @@ import json
 import re
 import sys
 
+from collections import defaultdict
+
 import boto3
 
 from colorama import Fore
@@ -34,6 +36,30 @@ VIOLATION_EXCLUSION_REGEXES = [
     re.compile(r"gevent-.*-cp310-.*-win_amd64.whl"),  # Can be removed after dropping Python 3.10
     re.compile(r"gdbgui-0.13.2.0-py3-none-any.whl"),  # Maybe not uploaded by the CI, so keep it for now
 ]
+
+
+def _normalize_pkg_dir(name: str) -> str:
+    """Normalize S3 package directory naming differences.
+
+    Historically, this repo used both underscore and dash package directories on S3
+    (e.g. ``flask_compress`` vs ``flask-compress``). Those can legitimately contain the
+    same wheel basenames. We treat that as a warning, not a violation.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _canonical_pkg_dirs_from_wheel_filename(wheel_name: str) -> set[str]:
+    """Return PEP 503-normalized candidate package dirs derived from the wheel filename.
+
+    Mirrors the wheel-name parsing used by ``upload_wheels.py`` (first ``-`` before a digit).
+    """
+    parsed = parse_wheel_name(wheel_name)
+    if parsed:
+        return {_normalize_pkg_dir(parsed[0])}
+    match = re.compile(r"^(.+?)-(\d+)").search(wheel_name)
+    if not match:
+        return set()
+    return {_normalize_pkg_dir(match.group(1))}
 
 
 def get_supported_python_versions(supported_python_json: str) -> list[str]:
@@ -76,6 +102,15 @@ def is_unsupported_python(wheel_name: str, oldest_supported: str) -> tuple[bool,
     return False, ""
 
 
+def _report_violation(violations: dict[str, str], wheel: str, reason: str) -> None:
+    """Record and print one violation per wheel basename (first reason wins)."""
+    if wheel in violations:
+        return
+    violations[wheel] = reason
+    print_color(f"-- {wheel}", Fore.RED)
+    print(f"   {reason}")
+
+
 def main():
     if len(sys.argv) < 4:
         raise SystemExit(
@@ -103,24 +138,55 @@ def main():
 
     # Get all wheels from S3
     print_color("---------- SCANNING S3 WHEELS ----------")
-    wheels = []
+    basename_to_keys: defaultdict[str, list[str]] = defaultdict(list)
     for obj in bucket.objects.filter(Prefix="pypi/"):
         if obj.key.endswith(".whl"):
             wheel_name = obj.key.split("/")[-1]
-            wheels.append(wheel_name)
+            basename_to_keys[wheel_name].append(obj.key)
 
-    print(f"Found {len(wheels)} wheels on S3\n")
+    wheel_names = sorted(basename_to_keys.keys())
+    wheels_on_s3_count = sum(len(v) for v in basename_to_keys.values())
+
+    print(f"Found {wheels_on_s3_count} wheel objects ({len(wheel_names)} unique filenames) on S3\n")
 
     # Check each wheel
     print_color("---------- CHECKING WHEELS ----------")
-    violations = []
+    violations: dict[str, str] = {}
     old_python_wheels = []
 
-    for wheel in wheels:
+    for wheel in wheel_names:
         # Check for unsupported Python versions (warning only, not a violation)
         is_old, reason = is_unsupported_python(wheel, oldest_supported_python)
         if is_old:
             old_python_wheels.append((wheel, reason))
+            continue
+
+        keys_for_name = basename_to_keys[wheel]
+        if len(keys_for_name) > 1:
+            # Determine whether the duplicate keys are only due to directory normalization
+            # differences (underscore vs dash). Those are historical and are not treated as
+            # violations (we cannot infer which object is authoritative without comparing bytes).
+            pkg_dirs = []
+            for k in keys_for_name:
+                parts = k.split("/")
+                pkg_dirs.append(parts[1] if len(parts) >= 3 else "")
+            normalized = {_normalize_pkg_dir(d) for d in pkg_dirs if d}
+            reason_dup = "Duplicate wheel basename across multiple S3 keys: " + ", ".join(sorted(keys_for_name))
+            canonical = _canonical_pkg_dirs_from_wheel_filename(wheel)
+            if len(normalized) <= 1 or (canonical and canonical.issubset(normalized)):
+                print_color(f"-- {wheel}", Fore.YELLOW)
+                print(f"   {reason_dup}")
+                if len(normalized) <= 1:
+                    print(f"   Note: directories normalize to {next(iter(normalized), '')!r}; treated as warning")
+                else:
+                    print(
+                        "   Note: at least one prefix matches the wheel's canonical project dir "
+                        f"{sorted(canonical)!r}; extra keys are likely stale/wrong-path duplicates; treated as warning"
+                    )
+            else:
+                _report_violation(violations, wheel, reason_dup)
+
+        if wheel in violations:
             continue
 
         # Check against exclude_list (actual violations)
@@ -130,21 +196,19 @@ def main():
         if should_exclude:
             if any(rx.search(wheel) for rx in VIOLATION_EXCLUSION_REGEXES):
                 continue
-            violations.append((wheel, reason))
-            print_color(f"-- {wheel}", Fore.RED)
-            print(f"   {reason}")
+            _report_violation(violations, wheel, reason)
 
     print_color("---------- END CHECKING ----------")
 
     # Statistics
     print_color("---------- STATISTICS ----------")
-    print(f"Checked: {len(wheels)} wheels")
+    print(f"Checked: {wheels_on_s3_count} wheel objects ({len(wheel_names)} unique filenames)")
     if old_python_wheels:
         print_color(f"Old Python wheels: {len(old_python_wheels)} (warning only)", Fore.YELLOW)
     if violations:
         print_color(f"Violations: {len(violations)}", Fore.RED)
         print_color("\nWheel paths that should be deleted:", Fore.RED)
-        for wheel, _ in violations:
+        for wheel in sorted(violations):
             parsed = parse_wheel_name(wheel)
             pkg = parsed[0] if parsed else wheel.replace(".whl", "")
             print(f'"/pypi/{pkg}/{wheel}"')

--- a/yaml_list_adapter.py
+++ b/yaml_list_adapter.py
@@ -84,11 +84,21 @@ class YAMLListAdapter:
     requirements: set = set()
 
     def __init__(self, yaml_file: str, exclude: bool = False, current_platform: Optional[str] = None) -> None:
+        self._yaml_list: list = []
         try:
             with open(yaml_file, "r") as f:
-                self._yaml_list = yaml.load(f, yaml.Loader)
+                raw = yaml.load(f, yaml.Loader)
         except FileNotFoundError:
             print_color(f"File not found, please check the file: {yaml_file}", Fore.RED)
+            raw = None
+        if isinstance(raw, dict):
+            # Optional mapping root (e.g. includes under ``includes``); list root is still supported.
+            self._yaml_list = raw.get("includes") or raw.get("include_packages") or []
+        elif isinstance(raw, list):
+            self._yaml_list = raw
+        elif raw is not None:
+            print_color(f"Unexpected YAML root type in {yaml_file}: {type(raw).__name__}", Fore.RED)
+            self._yaml_list = []
         self.exclude = exclude
 
         # When building wheels: only exclude entries that apply to this platform


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

This PR introduces enhanced checking of the wheels on S3 to not overwrite wheels we don't want to (mostly the same naming), e.g., ARMv7 "classic" and "legacy".

Also, for ARMv7, we do not require manylinux tags to not bundle the libraries to the wheel and prefer piwheels index before the official PyPI.

---

The segfault is a wheel-identity collision problem, not a code bug.

ARMv7 wheels are built on two parallel runners with different glibc baselines:

**Standard:** Debian Bookworm container → glibc 2.36
**Legacy:** Debian Bullseye container → glibc 2.31 (and links libffi.so.7, OpenSSL 1.1, older Rust, etc.)

Before this branch, both runners emitted wheels with identical PEP 425 filenames (e.g. `cryptography-…-cp39-cp39-linux_armv7l.whl`). When the per-arch artifacts were merged and uploaded to `S3` at `pypi/<pkg>/<filename>`, the second upload silently overwrote the first. End users on Bullseye-class systems then `pip` install-ed a wheel actually built against `glibc 2.36` / `libffi.so.8` — and the C extension segfaults at import or first call when it resolves a versioned symbol that the older runtime doesn't have.

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

We now do not force the ARMv7 wheels to produce manylinux wheels, so there is no need to bundle the libs to the wheels, which is the main cause of this issue - because of the library mismatch.

cffi wheel example:
<img width="716" height="292" alt="image" src="https://github.com/user-attachments/assets/d8c43537-d46f-4c9c-ad37-fc8cd79723b7" />


## Testing

- workflow run: https://github.com/espressif/idf-python-wheels/actions/runs/26100586495
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
